### PR TITLE
Avoid using API 33 (Android 13) on older devices

### DIFF
--- a/app/src/main/java/spam/blocker/ui/main/MainActivity.kt
+++ b/app/src/main/java/spam/blocker/ui/main/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalView
+import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import spam.blocker.G
 import spam.blocker.R
@@ -194,10 +195,12 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-        registerReceiver(broadcastReceiver, IntentFilter().apply {
-            addAction(Def.ON_NEW_CALL)
-            addAction(Def.ON_NEW_SMS)
-        }, Context.RECEIVER_EXPORTED)
+        ContextCompat.registerReceiver(this, broadcastReceiver,
+            IntentFilter().apply {
+                addAction(Def.ON_NEW_CALL)
+                addAction(Def.ON_NEW_SMS)
+            },
+            ContextCompat.RECEIVER_EXPORTED)
     }
 
     private fun onTabSelected(route: String) {


### PR DESCRIPTION
Flag Context.RECEIVER_EXPORTED is only available on Android 13 (API 33) or later. Since the app supports Android 10 (API 29), use ContextCompat so the flag will be suppressed on older devices and avoid any compatibility problems.