### PR TITLE
Use Android API to match numbers more accurately

### DIFF
--- a/app/src/androidTest/java/spam/blocker/service/RuleTest.kt
+++ b/app/src/androidTest/java/spam/blocker/service/RuleTest.kt
@@ -22,6 +22,7 @@ import spam.blocker.util.ContactInfo
 import spam.blocker.util.Contacts
 import spam.blocker.util.Now
 import spam.blocker.util.Permissions
+import spam.blocker.util.PhoneNumber
 import spam.blocker.util.SharedPref.Contact
 import spam.blocker.util.SharedPref.Dialed
 import spam.blocker.util.SharedPref.OffTime
@@ -103,7 +104,8 @@ class RuleTest {
         every { Permissions.isReadSmsPermissionGranted(any()) } returns true
     }
     private fun mock_calls(rawNumber: String, direction: Int, repeatedTimes: Int, atTimeMillis: Long) {
-        every { Permissions.countHistoryCallByNumber(any(), rawNumber, direction, any()) } answers {
+        val number = PhoneNumber(ctx, rawNumber)
+        every { Permissions.countHistoryCallByNumber(any(), number, direction, any()) } answers {
             val withinMillis = lastArg<Long>()
             val mockNow = Now.currentMillis()
             if (atTimeMillis in mockNow - withinMillis..mockNow) {
@@ -114,7 +116,8 @@ class RuleTest {
         }
     }
     private fun mock_sms(rawNumber: String, direction: Int, repeatedTimes: Int, atTimeMillis: Long) {
-        every { Permissions.countHistorySMSByNumber(any(), rawNumber, direction, any()) } answers {
+        val number = PhoneNumber(ctx, rawNumber)
+        every { Permissions.countHistorySMSByNumber(any(), number, direction, any()) } answers {
             val withinMillis = lastArg<Long>()
             val mockNow = Now.currentMillis()
             if (atTimeMillis in mockNow - withinMillis..mockNow) {

--- a/app/src/main/java/spam/blocker/service/Checker.kt
+++ b/app/src/main/java/spam/blocker/service/Checker.kt
@@ -16,6 +16,7 @@ import spam.blocker.db.SpamTable
 import spam.blocker.def.Def
 import spam.blocker.util.Contacts
 import spam.blocker.util.Permissions
+import spam.blocker.util.PhoneNumber
 import spam.blocker.util.SharedPref.Contact
 import spam.blocker.util.SharedPref.Dialed
 import spam.blocker.util.SharedPref.RecentApps
@@ -187,10 +188,12 @@ class Checker { // for namespace only
 
             val durationMillis = durationMinutes.toLong() * 60 * 1000
 
+            val phoneNumber = PhoneNumber(ctx, rawNumber)
+
             // count Calls from real call history
             var nCalls = Permissions.countHistoryCallByNumber(
                 ctx,
-                rawNumber,
+                phoneNumber,
                 Def.DIRECTION_INCOMING,
                 durationMillis
             )
@@ -208,7 +211,7 @@ class Checker { // for namespace only
             // count SMSs from real SMS history
             var nSMSs = Permissions.countHistorySMSByNumber(
                 ctx,
-                rawNumber,
+                phoneNumber,
                 Def.DIRECTION_INCOMING,
                 durationMillis
             )
@@ -250,15 +253,16 @@ class Checker { // for namespace only
             val durationMillis = durationDays.toLong() * 24 * 3600 * 1000
 
             // repeated count of call/sms, sms also counts
+            val phoneNumber = PhoneNumber(ctx, rawNumber)
             val nCalls = Permissions.countHistoryCallByNumber(
                 ctx,
-                rawNumber,
+                phoneNumber,
                 Def.DIRECTION_OUTGOING,
                 durationMillis
             )
             val nSMSs = Permissions.countHistorySMSByNumber(
                 ctx,
-                rawNumber,
+                phoneNumber,
                 Def.DIRECTION_OUTGOING,
                 durationMillis
             )

--- a/app/src/main/java/spam/blocker/ui/setting/quick/Dialed.kt
+++ b/app/src/main/java/spam/blocker/ui/setting/quick/Dialed.kt
@@ -66,6 +66,7 @@ fun Dialed() {
                         ctx,
                         listOf(
                             NormalPermission(Manifest.permission.READ_CALL_LOG),
+                            NormalPermission(Manifest.permission.READ_PHONE_STATE, true),
                             NormalPermission(Manifest.permission.READ_SMS, true)
                         )
                     ) { granted ->

--- a/app/src/main/java/spam/blocker/ui/setting/quick/RepeatedCall.kt
+++ b/app/src/main/java/spam/blocker/ui/setting/quick/RepeatedCall.kt
@@ -90,6 +90,7 @@ fun RepeatedCall() {
                         ctx,
                         listOf(
                             NormalPermission(Manifest.permission.READ_CALL_LOG),
+                            NormalPermission(Manifest.permission.READ_PHONE_STATE, true),
                             NormalPermission(Manifest.permission.READ_SMS, true)
                         )
                     ) { granted ->

--- a/app/src/main/java/spam/blocker/util/PhoneNumber.kt
+++ b/app/src/main/java/spam/blocker/util/PhoneNumber.kt
@@ -1,0 +1,84 @@
+package spam.blocker.util
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Build
+import android.telephony.PhoneNumberUtils
+import android.telephony.SubscriptionManager
+import android.telephony.TelephonyManager
+import android.util.Log
+import androidx.core.content.getSystemService
+
+class PhoneNumber(private val ctx: Context, private val rawNumber: String) {
+    private val candidateCountries: Set<String> by lazy {
+        determinePossibleCountries()
+    }
+
+    fun isSame(otherNumber: String): Boolean {
+        if (rawNumber == otherNumber) { // short circuit
+            return true
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            candidateCountries.forEach {
+                if(PhoneNumberUtils.areSamePhoneNumber(rawNumber, otherNumber, it)) {
+                    return true
+                }
+            }
+        } else {
+            @Suppress("deprecation") // deliberately using old API for old devices
+            if(PhoneNumberUtils.compare(ctx, rawNumber, otherNumber)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun determinePossibleCountries(): Set<String> {
+        val codes = mutableSetOf<String?>()
+        // Determine country for each mobile network the device is currently in:
+        val telephony = ctx.getSystemService<TelephonyManager>()!!
+        codes += telephony.networkCountryIso
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val slots = telephony.activeModemCount
+            for (slot in 0..<slots) {
+                try {
+                    codes += telephony.getNetworkCountryIso(slot)
+                } catch (e: IllegalArgumentException) {
+                    // Prevent failing due to race condition:
+                    Log.d("slot", "Rejected slot $slot (of total $slots)", e)
+                }
+            }
+        }
+        // Determine the country for each of the SIM cards:
+        if (Permissions.isPhoneStatePermissionGranted(ctx)) {
+            val subscription = ctx.getSystemService<SubscriptionManager>()
+            subscription?.activeSubscriptionInfoList?.forEach { sub ->
+                codes += sub.countryIso
+            }
+        }
+
+        return codes
+            .filterNotNull()
+            .filter { it.isNotEmpty() }
+            .map { it.uppercase() }
+            .toSet()
+            .ifEmpty { setOf("ZZ") } // ZZ = unknown country
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        if (javaClass != other?.javaClass) {
+            return false
+        }
+        other as PhoneNumber
+        return rawNumber == other.rawNumber
+    }
+
+    override fun hashCode(): Int {
+        return rawNumber.hashCode()
+    }
+}


### PR DESCRIPTION
Match against the call/SMS history using Android API instead of the old logic based on equality. In this way the same number represented in different ways (such as national and international formats) will be recognized as such.

For example, it's common for users who cross national borders often to store contacts with numbers in international (E.164) format such as +99-1234567, so the contact can be dialed no matter in which country the user is at. When the user dials or messages that contact, the number stored in Android's log is +99-1234567. However, when the user is in the same country as the contact (country with code +99), and receives a call from that number, the number is going to be identified as local number 01234567 instead.

In another more complicated example, countries such as Brazil have more complicated numbering plans with area codes and the same number could appear multiple times in the phone log as: +55-99-123456789 or 99-123456789 or 099-123456789 or 123456789 depending on if the user called or received the call and if they were in the same geographical area or not.

In the previous logic these numbers were not considered the same, defeating any "repeated call" or "dialed" rules. This change fixes this particular bug.

Determining an assumed country code is necessary for the new logic to work. What the new algorithm does is to gather a number of candidate country codes from multiple sources:
1. mobile networks the device is currently connected to
2. countries of the active SIM cards (requires READ_PHONE_STATE permission, skipped if not granted)