### PR TITLE
Issue templates (proposal)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,91 @@
+name: Bug Report
+description: Report an issue in the app
+labels: [bug]
+body:
+
+  - type: textarea
+    id: reproduce-steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide an example of the issue.
+      placeholder: |
+        Example:
+          1. First step
+          2. Second step
+          3. Issue here
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      placeholder: |
+        Example:
+          "This should happen..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      placeholder: |
+        Example:
+          "This happened instead..."
+    validations:
+      required: true
+
+  - type: input
+    id: SpamBlocker-version
+    attributes:
+      label: SpamBlocker version
+      description: |
+        You can find your SpamBlocker version in **About** section.
+      placeholder: |
+        Example: "v3.2"
+    validations:
+      required: true
+
+  - type: input
+    id: android-version
+    attributes:
+      label: Android version
+      description: |
+        You can find this somewhere in **About** section of your Android settings.
+      placeholder: |
+        Example: "Android 12"
+    validations:
+      required: true
+
+  - type: input
+    id: android-rom
+    attributes:
+      label: Android Custom/Specific ROM or Device
+      description: |
+        You can find this somewhere in **About** section of your Android settings. If you are not sure or you don't know what a ROM is, just specify your device model.
+      placeholder: |
+        Examples: "Stock, One UI, EMUI, MIUI, GrapheneOS, LineageOS, CalyxOS, etc..."
+        If unsure: "Google Pixel 7, Samsung Galaxy S22, OnePlus 10, etc..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other details
+      placeholder: |
+        Additional details and attachments.
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      description: Your issue will be closed if you haven't done these steps.
+      options:
+        - label: I have searched the existing issues and this is a new ticket, **NOT** a duplicate or related to another open issue.
+          required: true
+        - label: I have written a short but informative title.
+          required: true
+        - label: I will fill out all of the requested information in this form.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/aj3423/SpamBlocker/discussions
+    about: Ask a question or request support about SpamBlocker

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Suggest a feature to improve SpamBlocker
+labels: [enhancement]
+body:
+
+  - type: textarea
+    id: feature_problem_related-description
+    attributes:
+      label: Describe a related problem (optional)
+      description: Is your feature request related to a problem in SpamBlocker?
+      placeholder: |
+        Example:
+          "I'm always frustrated when [...]"
+    validations:
+      required: false
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Describe your suggested feature
+      description: How could SpamBlocker be improved?
+      placeholder: |
+        Example:
+          "It should work like this..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: feature_alternative-description
+    attributes:
+      label: Describe alternatives you've considered for your suggested feature
+      description: A clear description of any alternative solutions or features you've considered
+      placeholder: |
+        Example:
+          "It should work like this..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: other-details
+    attributes:
+      label: Other details
+      placeholder: |
+        Additional details, links and attachments.
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      description: Your issue will be closed if you haven't done these steps.
+      options:
+        - label: I have searched the existing feature request and this is a new ticket, **NOT** a duplicate or related to another open feature request.
+          required: true
+        - label: I have written a short but informative title.
+          required: true
+        - label: I will fill out all of the requested information in this form.
+          required: true
+ 


### PR DESCRIPTION
Hi;

Simple proposal to integrate the issue templates, slightly modified to adapt to SpamBlocker.

Link to the issue templates informations:
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms

If you don't like it, don't hesitate to modify this PR, or delete it if necessary, thank you
