### PR TITLE
Add zh-TW Traditional Chinese locale

### DIFF
--- a/app/src/main/res/values-zh-rTW/strings_1.xml
+++ b/app/src/main/res/values-zh-rTW/strings_1.xml
@@ -1,0 +1,59 @@
+<resources>
+    <string name="app_name">來電過濾器</string>
+    <string name="setting">設定</string>
+    <string name="call">通話</string>
+    <string name="sms">簡訊</string>
+    <string name="enable">啟用</string>
+    <string name="sms_content_pattern">簡訊內容</string>
+    <string name="invalid_regex_pattern">正規表示式無效</string>
+    <string name="pattern_contain_invisible_characters">偵測到隱藏字元</string>
+    <string name="pattern_contain_leading_zeroes">不必加上前置 0，檢查前會自動移除。</string>
+    <string name="pattern_contain_leading_plus">不必加上開頭的 +，檢查前會自動移除。</string>
+    <string name="check_balloon_for_explanation">請檢視 [號碼規則] 的說明以取得詳細解釋。</string>
+    <string name="invalid_number">號碼無效</string>
+    <string name="description">描述</string>
+    <string name="new_">新增</string>
+    <string name="delete">刪除</string>
+    <string name="clear">清除</string>
+    <string name="test">測試</string>
+    <string name="save">儲存</string>
+    <string name="whitelist">白名單</string>
+    <string name="blacklist">黑名單</string>
+    <string name="content">內容</string>
+    <string name="priority">優先順序</string>
+    <string name="deleted_filter">（已刪除的規則）</string>
+    <string name="apply_to">套用至</string>
+    <string name="undelete">取消刪除</string>
+    <string name="passed_by_default">預設放行</string>
+    <string name="copy">複製</string>
+    <string name="quick_copy">快速複製</string>
+    <string name="yes">是</string>
+    <string name="no">否</string>
+    <string name="ok">確定</string>
+    <string name="miscellaneous">其他功能</string>
+    <string name="quick_settings">快速設定</string>
+    <string name="regex_settings">正規表示式設定</string>
+    <string name="backup">備份</string>
+    <string name="import_">匯入</string>
+    <string name="export">匯出</string>
+    <string name="config_text">設定文字</string>
+    <string name="imported_successfully">匯入成功</string>
+    <string name="import_fail">匯入失敗</string>
+    <string name="prompt_go_to_permission_setting">
+        <![CDATA[
+        此功能需要權限：<br>
+        <br>
+        <font color="#00BFFF">%s</font><br>
+        <br>
+        必須在系統設定中手動啟用。<br>
+        要開啟該設定頁面嗎？
+        ]]>
+    </string>
+    <string name="emergency_call">緊急通話</string>
+    <string name="label_number_rules">號碼規則</string>
+    <string name="number_rule">號碼規則</string>
+    <string name="label_content_rules">簡訊規則</string>
+    <string name="content_rule">簡訊規則</string>
+    <string name="recent_apps"><short>最近使用的應用程式</short></string>
+    <string name="allow_contact">聯絡人</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_10.xml
+++ b/app/src/main/res/values-zh-rTW/strings_10.xml
@@ -1,0 +1,54 @@
+<resources>
+    <string name="help_number_rules">
+        <![CDATA[
+        這些規則適用於來電與簡訊的號碼。<br>
+        <br>
+        <h5><font color="#00BFFF"> - 範例</font></h5>
+        在 <a href="https://github.com/aj3423/SpamBlocker/wiki/Regex-Templates">Wiki 頁面</a>上有一些範例。<br>
+        <br>
+        <h5><font color="#00BFFF"> - 規則最佳化</font></h5>
+        為了簡化正規表示式，
+          檢查前會移除<font color="#fa7f71"><b>+</b></font>和<font color="#fa7f71"><b>前置零</b></font>，例如：<br>
+        &emsp; 以下所有格式：<br>
+        &emsp;&emsp; 123456789 &emsp;（一般號碼）<br>
+        &emsp;&emsp; <font color="#fa7f71"><b>+</b></font>123456789 &emsp;（帶有前置 <font color="#fa7f71"><b>+</b></font>）<br>
+        &emsp;&emsp; <font color="#fa7f71"><b>0</b></font>123456789 &emsp;（帶有本地區域碼前置 <font color="#fa7f71"><b>0</b></font>）<br>
+        &emsp;&emsp; <font color="#fa7f71"><b>00</b></font>123456789 &emsp;（兩個 <font color="#fa7f71"><b>0</b></font>）<br>
+        &emsp; 它們<b>都</b>會被視為 123456789 並可以被 <font color="#03DAC5"><b>123.*</b></font> 符合<br>
+        可以使用「原始號碼」正規表示式標記將這項最佳化<b>停用</b>。<br>
+        <br>
+        <h5><font color="#00BFFF"> - 一些常見的規則</font></h5>
+        &ensp; - 任何號碼：<font color="#03DAC5"><b>.*</b></font>（正規表示式 .* 等同於其他應用程式中的萬用字元 *）<br>
+        &ensp; - 完全符合號碼：<font color="#03DAC5"><b>12345</b></font><br>
+        &ensp; - 以 400 開頭：<font color="#03DAC5"><b>400.*</b></font><br>
+        &ensp; - 以 123 結尾：<font color="#03DAC5"><b>.*123</b></font><br>
+        &ensp; - 7 位數字：<font color="#03DAC5"><b>.{7}</b></font><br>
+        &ensp; - 少於 5 位：<font color="#03DAC5"><b>.{0,4}</b></font><br>
+        &ensp; - 超過 10 位：<font color="#03DAC5"><b>.{11,}</b></font><br>
+        &ensp; - 未知/私人/空號碼：<font color="#03DAC5"><b>.{0}</b></font> 或 <font color="#03DAC5"><b>^$</b></font><br>
+        &ensp; - 符合任一規則：<font color="#03DAC5"><b>(12.*|.*89)</b></font><br>
+        &ensp; - 以 400 開頭，可能有或沒有前置國碼 11：<font color="#03DAC5"><b>(?:11)?400.*</b></font><br>
+        <br>
+        <h5><font color="#00BFFF"> - 介面相關</font></h5>
+        取消勾選核取方塊可停用規則，<font color="#fa7f71"><b>向左滑動可刪除</b></font>規則。<br>
+        <br>
+        清單會依優先順序遞減、描述遞增和規則遞增的順序<b>顯示</b>。<br>
+        <br>
+        <h5><font color="#00BFFF"> - 從 .csv 匯入規則</font></h5>
+        長按「新增」按鈕可從 .csv 檔案匯入號碼。<br>
+        <brg>
+        ]]>
+    </string>
+    <string name="import_csv_columns">
+        <![CDATA[
+         支援的欄位：<br>
+         - <no_translate><b>pattern</b></no_translate>：正規表示式（<b>必填</b>）<br>
+         - <no_translate><b>description</b></no_translate>：描述<br>
+         - <no_translate><b>priority</b></no_translate>：優先順序，預設值 1<br>
+         - <no_translate><b>flags</b></no_translate>：1（套用至通話），2（套用至簡訊），3（兩者），預設值 3<br>
+         - <no_translate><b>isBlacklist</b></no_translate>：黑名單或白名單。<no_translate>true</no_translate> 或 <no_translate>false</no_translate>，預設值 <no_translate>true</no_translate><br>
+         - <no_translate><b>blockType</b></no_translate>：封鎖類型。0~2 對應三種封鎖類型，預設值 0<br>
+         - <no_translate><b>importance</b></no_translate>：通知類型。0~4 對應五種通知類型，預設值 2<br>
+        ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_11.xml
+++ b/app/src/main/res/values-zh-rTW/strings_11.xml
@@ -1,0 +1,66 @@
+<resources>
+    <string name="for_example">例如：</string>
+    <string name="yesterday_abbrev">昨天</string>
+    <string name="help_meeting_mode">
+        <![CDATA[
+        在線上視訊會議期間拒接來電。<br> <br>
+        會檢查所選應用程式是否正在執行<b>前景服務</b>，
+        這是視訊會議應用程式常用來保持連線的方式。<br>
+        <br>
+        適用於通話和簡訊。<br>
+        <br>
+        <font color="#ea86ff"><b>預設優先順序：20</b></font>
+        ]]>
+    </string>
+    <string name="in_meeting">會議模式</string>
+    <string name="search_number">搜尋號碼</string>
+    <string name="http_header">HTTP 標頭</string>
+    <string name="help_http_header">
+        <![CDATA[
+        每行一個屬性。<br>
+        ]]>
+    </string>
+    <string name="tags_supported">
+        <![CDATA[
+        支援的標籤：<br><br>
+        ]]>
+    </string>
+    <string name="auth_tags">
+        <![CDATA[
+        - <font color="#00BFFF"><b>{basic_auth(username:password)}</b></font><br>
+        &ensp; 用於需要 HTTP 基本驗證的 API。例如：<br>
+        &emsp; <font color="#888888">{basic_auth(111:222)}</font><br>
+        &ensp; 將被解析為：<br>
+        &emsp; <font color="#888888">Authorization: Basic MTExOjIyMg== </font><br>
+        ]]>
+    </string>
+    <string name="log_sms_content_to_db">記錄簡訊</string>
+    <string name="initial_row_count">初始列數</string>
+    <plurals name="rows">
+        <item quantity="other">%d 列</item>
+    </plurals>
+    <string name="label_max_none_scroll_items">捲動列表顯示門檻</string>
+    <string name="help_max_none_scroll_items">
+        <![CDATA[
+        清單中的筆數超過此數值時會出現捲動列。
+        ]]>
+    </string>
+    <string name="label_max_scroll_height">捲動高度</string>
+    <string name="help_max_scroll_height">
+        <![CDATA[
+        當出現捲動列時，此值代表清單高度佔螢幕的百分比。
+        ]]>
+    </string>
+    <string name="label_max_regex_lines">正規表示式最大行數</string>
+    <string name="help_max_regex_lines">
+        <![CDATA[
+        正規表示式文字的最大顯示行數，超過的文字將被截斷並顯示省略號。
+        ]]>
+    </string>
+    <string name="label_max_desc_lines">描述最大行數</string>
+    <string name="help_max_desc_lines">
+        <![CDATA[
+        描述文字的最大顯示行數，超過的文字將被截斷並顯示省略號。
+        ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_12.xml
+++ b/app/src/main/res/values-zh-rTW/strings_12.xml
@@ -1,0 +1,103 @@
+<resources>
+    <string name="help_instant_query">
+        <![CDATA[
+        即時在線上查詢來電號碼，會同時查詢多個 API 端點，並採用第一個收到的結果，忽略後續結果。<br>
+        <br>
+        只適用於來電，不適用於簡訊。<br>
+        <br>
+        此功能預設為最低優先順序，代表僅在來電符合所有其他規則後才會觸發。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：-1</b></font>
+        ]]>
+    </string>
+    <string name="instant_query">即時查詢</string>
+    <string name="query">查詢</string>
+    <string name="negative_identifier">負面識別</string>
+    <string name="hint_negative_identifier">
+        例如：(\"valid\":false)
+    </string>
+    <string name="help_negative_identifier">
+        如果在結果中找到此正規表示式，將被識別為垃圾號碼。
+    </string>
+    <string name="positive_identifier">正面識別</string>
+    <string name="hint_positive_identifier">
+        例如：(\"valid\":true)
+    </string>
+    <string name="help_positive_identifier">
+        <![CDATA[
+        如果在結果中找到此正規表示式，將被識別為非垃圾號碼，此為選用設定。<br>
+        <br>
+        通常這是<b>不必要的</b>，某些 API 提供者會將未知號碼識別為非垃圾號碼，
+        只有在 API 真的很準確時才使用此選項。
+        ]]>
+    </string>
+    <string name="category_identifier">類別識別</string>
+    <string name="hint_category_identifier">
+        例如：\"type\":\"(.+?)\"
+    </string>
+    <string name="help_category_identifier">
+        <![CDATA[
+        選用。<br>
+        一旦號碼被識別，此正規表示式將用於擷取其類別（電話行銷、釣魚等）。
+        ]]>
+    </string>
+    <string name="action_parse_query_result">解析結果</string>
+    <string name="help_action_parse_query_result">
+        <![CDATA[
+        解析查詢結果，如果結果包含特定的正規表示式，該號碼將被識別為垃圾號碼。<br>
+        <br>
+        可以使用額外的正規表示式來擷取騷擾電話類別（選用）。
+        ]]>
+    </string>
+    <string name="action_intercept_call">攔截來電</string>
+    <string name="help_action_intercept_call">
+        <![CDATA[
+        來電號碼將被攔截並解析為不同的標籤：<br>
+        <br>
+        %s
+        <br>
+        這些標籤將用於建立 HTTP 網址，例如：<br>
+        <br>
+        1. 對於國際號碼如 <b>+122222</b>，這兩種寫法是相同的：<br>
+        - https://test.com/number=<b>{number}</b><br>
+        - https://test.com/number=<b>{cc}{domestic}</b><br>
+        將被解析為：<br>
+        https://test.com/number=<b>122222</b><br>
+        <br>
+        2. 對於本地號碼如 <b>12345</b>，您需要在設定中提供國碼，
+        或讓應用程式自動偵測。<br>
+        ]]>
+    </string>
+    <string name="action_intercept_sms">攔截簡訊</string>
+    <string name="help_action_intercept_sms">
+        <![CDATA[
+        收到的簡訊將被攔截，內容將被解析為標籤 <b>{sms}</b>，
+        可以在 HTTP 請求中使用。
+        ]]>
+    </string>
+    <string name="query_api">查詢 API</string>
+    <string name="report_api">回報 API</string>
+    <string name="number_filter">號碼過濾</string>
+    <string name="help_number_filter">
+        <![CDATA[
+        某些 API 服務只支援國際號碼，而某些只支援本地號碼。<br>
+        <br>
+        此正規表示式會相應地過濾號碼，不符合此規則的來電號碼將略過檢查。<br>
+        <br>
+        - 只檢查<b>國際號碼</b>：<br>
+        &ensp; <font color="#03DAC5"><b>\\+.*</b></font><br>
+        <br>
+        - 只檢查<b>本地號碼</b>：<br>
+        &ensp; <font color="#03DAC5"><b>0{1,2}.*</b></font><br>
+        <br>
+        - 檢查<b>任何號碼</b>：<br>
+        &ensp; <font color="#03DAC5"><b>.*</b></font>
+        ]]>
+    </string>
+    <string name="checking_template">正在檢查：%s，優先順序：%s</string>
+    <string name="skip_for_testing">測試時略過。</string>
+    <string name="allowed_by">放行原因：%s</string>
+    <string name="blocked_by">封鎖原因：%s</string>
+    <string name="outside_time_schedule">不在排程時段內，略過。</string>
+    <string name="android_ver_lower_than_11">Android 版本低於 11，略過。</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_13.xml
+++ b/app/src/main/res/values-zh-rTW/strings_13.xml
@@ -1,0 +1,128 @@
+<resources>
+    <string name="cleaning_up_history_db">
+        正在清理歷史資料庫，刪除時間戳記 %s 之前的記錄。
+    </string>
+    <string name="cleaning_up_spam_db">
+        正在清理騷擾號碼資料庫，刪除 %s 筆時間戳記早於 %s 的記錄。
+    </string>
+    <string name="resolved_url">解析後的網址：%s</string>
+    <string name="time_cost">執行時間：%s 毫秒。</string>
+    <string name="parsed_n_rules">已解析 %s 條規則。</string>
+    <string name="add_n_numbers_to_spam_db">正在新增 %s 個號碼至騷擾號碼資料庫。</string>
+    <string name="nothing_to_import">號碼清單為空，無資料可匯入。</string>
+    <string name="importing_n_numbers">正在匯入 %s 個號碼為正規表示式規則。</string>
+    <string name="create_rule_with_numbers">正在建立包含 %s 個號碼的規則。</string>
+    <string name="replace_rule_with_desc">正在取代描述為：%s 的規則。</string>
+    <string name="rule_with_desc_not_found">找不到描述為 %s 的規則。</string>
+    <string name="merging_rule_with_desc">正在合併描述為：%s 的規則。</string>
+    <string name="regex_count_after_merge">合併前規則數：%s，合併後：%s。</string>
+    <string name="replace_number_from_to">將號碼從 %s 取代為 %s。</string>
+    <string name="find_rule_with_desc">找到 %s 條描述為 %s 的規則。</string>
+    <string name="modify_n_rules">正在修改 %s 條規則。</string>
+    <string name="number_not_match_filter">號碼 %s 不符合過濾規則 %s，略過。</string>
+    <string name="fail_detect_cc">無法偵測國碼。</string>
+    <string name="identified_as_spam">已識別為垃圾號碼，類別：%s。</string>
+    <string name="identified_as_valid">已識別為有效號碼，類別：%s。</string>
+    <string name="unidentified_number">未識別的號碼。</string>
+    <string name="auto_detect_cc_permission">需要 READ_PHONE_STATE 權限才能自動偵測國碼。</string>
+    <string name="number_tags">
+        <![CDATA[
+        - <font color="#00BFFF"><b>{cc}</b></font><br>
+        &ensp; 國碼。<br>
+        - <font color="#00BFFF"><b>{domestic}</b></font><br>
+        &ensp; 本地號碼部分。<br>
+        - <font color="#00BFFF"><b>{number}</b></font><br>
+        &ensp; 完整號碼，包含國碼和本地號碼部分，不含前置 + 或 0。<br>
+        - <font color="#00BFFF"><b>{origin_number}</b></font><br>
+        &ensp; 原始號碼，可能包含前置 + 或 0。<br>
+        ]]>
+    </string>
+    <string name="sms_tags">
+        <![CDATA[
+        - <font color="#00BFFF"><b>{sms}</b></font><br>
+        &ensp; 簡訊內容。<br>
+        ]]>
+    </string>
+    <string name="time_tags">
+        <![CDATA[
+         <font color="#00BFFF"><b>{year}</b></font><br>
+         <font color="#00BFFF"><b>{month}</b></font><br>
+         <font color="#00BFFF"><b>{day}</b></font><br>
+         <font color="#00BFFF"><b>{hour}</b></font><br>
+         <font color="#00BFFF"><b>{minute}</b></font><br>
+         <font color="#00BFFF"><b>{second}</b></font><br>
+        &ensp; 個位數會補零，例如：<br>
+        &emsp; <font color="#888888">{year}-{month}-{day} {hour}:{minute}:{second}</font> <br>
+        &emsp; 變為 <br>
+        &emsp; <font color="#888888">2020-01-22 03:44:05</font><br>
+        <br>
+         <font color="#00BFFF"><b>{month_index}</b></font><br>
+         <font color="#00BFFF"><b>{day_index}</b></font><br>
+         <font color="#00BFFF"><b>{hour_index}</b></font><br>
+         <font color="#00BFFF"><b>{minute_index}</b></font><br>
+         <font color="#00BFFF"><b>{second_index}</b></font><br>
+        &ensp; 這些值不會補零，例如：<br>
+        &emsp; <font color="#888888">{month_index}-{day_index}</font> <br>
+        &emsp; 變為 <br>
+        &emsp; <font color="#888888">1-2</font><br>
+        <br>
+         <font color="#00BFFF"><b>{day_of_week}</b></font><br>
+         <font color="#00BFFF"><b>{day_of_week_index}</b></font><br>
+        &ensp; 這些可用於模擬輪替排程，例如：<br>
+        &emsp; <font color="#888888">執行每日備份，只保留最近七個備份。</font> <br>
+        ]]>
+    </string>
+    <string name="help_http_url">
+        <![CDATA[
+        支援的標籤：<br>
+        <br>
+        %s
+        <br>
+        %s
+        ]]>
+    </string>
+    <string name="api_preset_phoneblock"><no_translate>PhoneBlock 🇩🇪 🌐</no_translate></string>
+    <string name="help_api_preset_phoneblock">
+        <![CDATA[
+        主要為德國 FRITZ!Box 設計，但也適用於任何其他國家的電話號碼。<br>
+        <br>
+        支援使用雜湊值而非號碼本身進行查詢，提供更好的隱私保護。<br>
+        <br>
+        網站：<a href="https://phoneblock.net">https://phoneblock.net</a><br>
+        <br>
+        API：<a href="https://phoneblock.net/phoneblock/api/">https://phoneblock.net/phoneblock/api/</a>
+        ]]>
+    </string>
+    <string name="help_api_preset_phoneblock_authorization">
+        <![CDATA[
+        1. 在 <a href="https://phoneblock.net/phoneblock/login">https://phoneblock.net/phoneblock/login</a> 註冊帳號<br>
+        <br>
+        2. 在設定頁面：<a href="https://phoneblock.net/phoneblock/settings">https://phoneblock.net/phoneblock/settings</a>，
+         按下「產生 API 金鑰」按鈕。<br>
+        <br>
+        3. 在下方填入產生的 API 金鑰。
+        ]]>
+    </string>
+    <string name="not_enough_time_left">
+        通話過濾時間限制為 5 秒，加上時間函式不精確的 %s 毫秒緩衝，
+        實際總時限為 %s 毫秒。
+        前面步驟已花費 %s 毫秒，剩餘時間不足，略過。
+    </string>
+    <string name="action_filter_query_result">過濾騷擾電話</string>
+    <string name="help_action_filter_query_result">
+        <![CDATA[
+        從上一步驟識別的垃圾號碼產生<u>號碼清單</u>，準備匯入資料庫。
+        ]]>
+    </string>
+    <string name="another_thread_is_cancelled">另一個執行緒已取消。</string>
+    <string name="suggest_to_swipe">
+        <![CDATA[
+        <font color="#03DAC5"><b>向左滑動</b></font>可刪除。<br>
+        <br>
+        本應用程式中大多數卡片式介面元素都支援滑動手勢，
+        某些還支援<font color="#03DAC5"><b>向右滑動</b></font>，例如歷史記錄。
+        ]]>
+    </string>
+    <string name="bug_number">如果這是有效號碼，請在 GitHub 上回報。</string>
+    <string name="skip_alpha_empty_number">略過含字母或空的號碼。</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_14.xml
+++ b/app/src/main/res/values-zh-rTW/strings_14.xml
@@ -1,0 +1,95 @@
+<resources>
+    <string name="report_number">回報號碼</string>
+    <string name="report_number_require_call_log_permission">
+        為了避免重複來電或回撥號碼被誤報，
+        回報號碼功能需要通話紀錄權限。
+    </string>
+    <string name="http_method">方法</string>
+    <string name="http_post_body">POST 內容</string>
+    <string name="help_http_post_body">
+        <![CDATA[
+        支援的標籤：<br>
+        <br>
+        %s
+        ]]>
+    </string>
+    <string name="invalid_auth_credentials">請輸入有效的驗證資訊。</string>
+    <string name="delay">延遲</string>
+    <string name="exclude_services">排除服務</string>
+    <string name="help_exclude_bg_service">
+        <![CDATA[
+        某些應用程式會執行額外的前景服務，可在此新增服務名稱來排除它們。<br>
+        <br>
+        尋找服務名稱的方法：<br>
+        &emsp; 1. 在該應用程式中啟動服務。<br>
+        &emsp; 2. 所有已啟動的服務名稱都會顯示在此。<br>
+        &emsp; 3. 點選名稱即可新增。<br>
+        <br>
+        您可以新增多個名稱，以逗號分隔。
+        ]]>
+    </string>
+    <string name="running_services">執行中的服務</string>
+    <string-array name="spam_categories">
+        <item>有效號碼</item>
+        <item>詐騙</item>
+        <item>行銷</item>
+        <item>問卷調查</item>
+        <item>政治</item>
+        <item>其他騷擾類型</item>
+    </string-array>
+    <string name="action_category_config">類別設定</string>
+    <string name="help_action_category_config">
+        <![CDATA[
+        僅支援以下騷擾電話類別，API 回傳的任何其他類別都應對應到其中之一。<br>
+        <br>
+         - <font color="#03DAC5"><b>{valid}</b></font><br>
+        &ensp; 回報為有效號碼，非騷擾電話。<br>
+        <br>
+         - <font color="#fa7f71"><b>{fraud}</b></font><br>
+         - <font color="#fa7f71"><b>{marketing}</b></font><br>
+         - <font color="#fa7f71"><b>{survey}</b></font><br>
+         - <font color="#fa7f71"><b>{political}</b></font><br>
+        <br>
+         - <font color="#fa7f71"><b>{other}</b></font><br>
+        &ensp; 後備騷擾電話類型，當無法歸類於上述類別時使用。<br>
+        ]]>
+    </string>
+    <string name="missing_category">
+        類別 %s 尚未在動作 %s 中設定，請在 API 設定中補上（若 API 支援該類別）。
+    </string>
+    <string name="target_text">目標文字</string>
+    <string name="match_found">找到符合結果</string>
+    <string name="match_not_found">找不到符合結果</string>
+    <string name="help_test_regex">
+        <![CDATA[
+        這只是用來測試此正規表示式是否符合某個文字，不包含其他規則。<br>
+        如要測試所有規則，請改用右下角的浮動測試按鈕。
+        ]]>
+    </string>
+    <string name="allow">允許</string>
+    <string name="block">封鎖</string>
+    <string name="seconds_short">秒</string>
+    <string name="within_seconds">指定秒數內</string>
+    <string name="sms_alert"><short>簡訊提醒</short></string>
+    <string name="help_sms_alert">
+        <![CDATA[
+        某些服務會先傳送簡訊通知您接下來會接到電話，通常在一分鐘內。<br>
+        <br>
+        例如這樣的簡訊：<br>
+        &ensp; <font color="#888888">［某服務］我們正要致電通知您……，請放心接聽。</font><br>
+        <br>
+        這類訊息的正規表示式可以是：<br>
+        &ensp; <font color="#03DAC5"><b>.*請.*接聽.*</b></font><br>
+        <br>
+        預設設定 <font color="#03DAC5"><b>120 秒</b></font> 表示在收到此類訊息後的兩分鐘內，
+        所有來電都會放行。<br>
+        <br>
+        適用於一般簡訊和快閃簡訊（Class 0 簡訊）。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：10</b></font>
+        ]]>
+    </string>
+    <string name="waning_using_wildcard_as_regex">使用萬用字元 `*` 時未加前置點號，您是否要使用 `.*`？</string>
+    <string name="import_as">匯入為</string>
+    <string name="api_key">API 金鑰</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_15.xml
+++ b/app/src/main/res/values-zh-rTW/strings_15.xml
@@ -1,0 +1,133 @@
+<resources>
+    <string name="api_preset_gemini">Gemini</string>
+    <string name="help_api_preset_gemini">
+        <![CDATA[
+        使用 Google Gemini AI 檢查簡訊內容，只需要 Google 帳號即可。
+        ]]>
+    </string>
+    <string name="gemini_api_key">Gemini API 金鑰</string>
+    <string name="help_api_preset_gemini_authorization">
+        <![CDATA[
+        1. 註冊並登入您的 Google 帳號：<br>
+         <a href="https://accounts.google.com/">https://accounts.google.com/</a><br>
+         <br>
+        2. 開啟 API 頁面：<br>
+         <a href="https://aistudio.google.com/app/apikey">https://aistudio.google.com/app/apikey</a><br>
+        <br>
+        3. 按下「建立 API 金鑰」按鈕。<br>
+        <br>
+        4. 複製金鑰，然後填入下方。
+        ]]>
+    </string>
+    <string name="spam_sms_prompt_template">
+        將此簡訊分類為「政治」、「詐騙」、「問卷調查」或「行銷」。
+        如果都不符合，請回答「有效」，否則僅回答類別，不要回答其他內容。
+        簡訊內容為：
+        {sms}
+    </string>
+    <string name="spam_sms_negative_category"><translate>(政治|詐騙|問卷調查|行銷)</translate></string>
+    <string name="spam_sms_positive_category">有效</string>
+    <string name="last_log">最新記錄</string>
+    <string name="executed_at">執行時間：</string>
+    <string name="not_executed_yet">尚未執行</string>
+    <string name="show_indicator">顯示標記</string>
+    <string name="help_show_indicator">
+        <![CDATA[
+        在號碼前顯示圖示，表示它是否存在於騷擾號碼資料庫中，或是否有任何正規表示式規則符合它。<br>
+        <br>
+        如此一來，您便可以快速確認歷史紀錄是否被規則涵蓋，無需逐一測試。<br>
+        <br>
+        <font color="#ffa500">注意：</font><br>
+        當有太多正規表示式規則時，這可能會影響效能。<br>
+        <br>
+        <b>範例：</b> <br>
+        <br>
+        <img src='ic_history_indicator_1'/> <br>
+        &ensp; - 第一個綠色數字圖示表示此號碼將被一條號碼規則允許。<br>
+        &ensp; - 第二個紅色簡訊圖示表示此簡訊內容將被一條內容規則封鎖。<br>
+        &ensp; - 第三個紅色資料庫圖示表示此號碼存在於騷擾號碼資料庫中。<br>
+        <br>
+        這些圖示是按<font color="#ea86ff"><b>優先順序</b></font>排列的，<b>第一個</b>圖示代表最終結果。該號碼規則有較高的優先順序，因此該簡訊最終會被允許。<br>
+        <br>
+        <img src='ic_history_indicator_2'/> <br>
+        &ensp; - 它將被一條內容規則允許。<br>
+        &ensp; - 它將被一條號碼規則封鎖。<br>
+        &ensp; - 它存在於騷擾號碼資料庫中。<br>
+        <br>
+        <b>第一個</b>圖示表示該訊息最終將被內容規則允許。<br>
+        <br>
+        <img src='ic_history_indicator_3'/> <br>
+        沒有號碼規則符合它，只有簡訊規則和資料庫。它將被一條簡訊規則封鎖。<br>
+        ]]>
+    </string>
+    <string name="enable_for_mms">啟用 MMS</string>
+    <string name="help_enable_for_mms">
+        <![CDATA[
+        MMS 訊息通常是垃圾訊息，除非您實際使用它們，否則不需要啟用。<br>
+        <br>
+        <font color="#ffa500">注意：</font><br>
+        群組訊息是 MMS，而非 SMS。<br>
+        <br>
+        MMS 將被視為 SMS 處理，只會處理文字內容，
+        多媒體內容（如圖片和音訊）將被忽略。<br>
+        <br>
+        需要兩個權限：RECEIVE_MMS 和 READ_SMS
+        ]]>
+    </string>
+    <string name="unknown_error">未知錯誤。</string>
+    <string name="checking_auth_credential">正在檢查驗證憑證。</string>
+    <string name="sms_bomb"><short>簡訊轟炸</short></string>
+    <string name="help_sms_bomb">
+        <![CDATA[
+        防簡訊轟炸。<br>
+        <br>
+        防止大量、持續的簡訊轟炸，這些通常主要由
+          OTP（一次性密碼）驗證組成。<br>
+        <br>
+        例如這樣的簡訊：<br>
+        &ensp; <font color="#888888">您的 OTP 是：1234。</font><br>
+        &ensp; <font color="#888888">這是您的驗證碼：1234。</font><br>
+        &ensp; <font color="#888888">1234 是您的確認碼。</font><br>
+        <br>
+        <h5><font color="#00BFFF">- 內容正規表示式</font></h5>
+        此功能只適用於符合此正規表示式的訊息，典型的正規表示式可能是：<br>
+        <font color="#fa7f71">.*(OTP|驗證碼|確認碼).*</font><br>
+        <br>
+        <h5><font color="#00BFFF">- 間隔</font></h5>
+        如果在這個時間間隔內收到後續的 OTP 訊息，將被視為
+          轟炸攻擊的一部分並被封鎖。<br>
+        （預設：30 秒）<br>
+        <br>
+        這將封鎖除了第一條以外的所有轟炸訊息。<br>
+        <br>
+        <h5><font color="#00BFFF">- 鎖定螢幕保護</font></h5>
+        啟用此功能可在鎖定螢幕模式下封鎖所有轟炸，包括第一條。<br>
+        <br>
+        通常，當您在等待驗證碼時，螢幕應該已經解鎖。
+        當裝置處於鎖定螢幕模式時收到此類訊息，很可能是轟炸。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：20</b></font>
+        ]]>
+    </string>
+    <string name="lockscreen_protection"><short>鎖定螢幕保護</short></string>
+    <string name="help_history_logging">
+        <![CDATA[
+            停用時，歷史記錄不會記錄在本機資料庫中，也不會在此顯示。<br>
+            <br>
+            <font color="#00BFFF"><b>有效期限</b></font><br>
+            &emsp; 啟用時，歷史記錄將在 N 天後過期，過期的記錄將自動刪除。
+        ]]>
+    </string>
+    <string name="never_expire"><short>永不過期</short></string>
+    <string name="enable_history_logging">記錄</string>
+    <string name="rcs_message">RCS 訊息</string>
+    <string name="help_rcs_message">
+        <![CDATA[
+            不支援 RCS。<br>
+            <br>
+            雖然 RCS 是標準協定，但每個訊息應用程式的實作方式都不同。<br>
+            <br>
+            一個替代方案是切換到 SMS。
+        ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_16.xml
+++ b/app/src/main/res/values-zh-rTW/strings_16.xml
@@ -1,0 +1,54 @@
+<resources>
+    <string name="help_report_number">
+        <![CDATA[
+        這裡設定的 API 將用於自動回報和手動回報。<br>
+        <br>
+        <h4><font color="#00BFFF">- 隱私權</font></h4>
+        API 端點將會看到您的：<br>
+        <br>
+         &ensp; - IP 位址<br>
+         &ensp; - TLS 和 TCP 指紋（可能會透露您的 Android 版本）<br>
+         &ensp; - 回報的號碼（包含您的國碼）<br>
+        <br>
+        不會回報其他任何資訊。<br>
+        <br>
+        <h4><font color="#00BFFF">- 手動回報</font></h4>
+		如果這裡啟用了任何 API，點選通話紀錄中的號碼時會出現回報按鈕。<br>
+		<br>
+		號碼將回報給<b>所有</b> API。<br>
+		<br>
+        <h4><font color="#00BFFF">- 自動回報</font></h4>
+		<font color="#6ED0ff"><b>回報延遲</b></font><br>
+        當通話被封鎖時，會有一小時的緩衝時間才進行回報。
+        如果在此緩衝時間內由於重複來電或回撥而允許該號碼，
+        將視為非垃圾號碼並取消回報。<br>
+        <br>
+		<font color="#6ED0ff"><b>回報類型</b></font><br>
+		1. <font color="#fa7f71"><b>不會</b></font>回報：<br>
+        <br>
+        - <font color="#fa7f71">簡訊號碼或內容</font><br>
+        - <font color="#fa7f71">允許的號碼</font><br>
+        - <font color="#fa7f71">測試</font><br>
+        以及以下封鎖類型：<br>
+        - <font color="#fa7f71">聯絡人正規表示式</font><br>
+        - <font color="#fa7f71">聯絡人群組正規表示式</font><br>
+        - <font color="#fa7f71">騷擾號碼資料庫</font><br>
+        - <font color="#fa7f71">會議模式</font><br>
+        - <font color="#fa7f71">即時查詢</font>（以防止 API 端點的號碼洩漏給其他競爭對手）<br>
+        <br>
+		2. <font color="#03DAC5"><b>會</b></font>回報被以下功能封鎖的號碼：<br>
+        <br>
+        - <font color="#03DAC5">非聯絡人</font>（嚴格）<br>
+        - <font color="#03DAC5">STIR 驗證</font><br>
+        - <font color="#03DAC5">號碼正規表示式</font><br>
+        <br>
+		3. 特殊情況：<br>
+        <br>
+        - 當被<font color="#03DAC5">即時查詢</font>封鎖時，只會回報給<b>相同</b>的 API 以提高該號碼的評分。
+         例如，當被來自 check.com 的 API 查詢封鎖時，只會回報給 check.com，不會回報給 others.com。<br>
+		<br>
+        - 當被<font color="#03DAC5">騷擾號碼資料庫</font>封鎖，且該記錄最初是由即時 API 查詢新增時，
+         基於相同理由，只會回報給<b>相同</b>的 API。<br>
+        ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_17.xml
+++ b/app/src/main/res/values-zh-rTW/strings_17.xml
@@ -1,0 +1,90 @@
+<resources>
+    <string name="emergency">緊急情況</string>
+    <string name="emergency_situation">緊急情況</string>
+    <string name="help_emergency_situation">
+        <![CDATA[
+        撥打緊急號碼後，在一段時間內允許所有來電。<br>
+        <br>
+        <h5><font color="#00BFFF">- 持續時間</font></h5>
+        預設設定 <font color="#03DAC5"><b>120 分鐘</b></font> 表示撥打緊急號碼後的 120 分鐘內將允許所有來電。<br>
+        <br>
+        <h5><font color="#00BFFF">- 檢查 STIR</font></h5>
+         - 停用時，將允許所有來電。<br>
+         - 啟用時，未獲 STIR 認證的來電將不被允許，僅允許「有效」和「未驗證」的來電。<br>
+        <br>
+        <h5><font color="#00BFFF">- 額外號碼</font></h5>
+        撥打此列表中的任何號碼也會觸發此功能。<br>
+        <br>
+        無需在此處明確新增 911 之類的號碼，因為 Android 為每個國家/地區內建了緊急號碼列表（例如：警察、消防、救護車）。<br>
+        <br>
+        使用逗號分隔號碼，例如：<br>
+        &ensp; <font color="#888888">111, 222, 3333</font><br>
+        <br>
+        <h5><font color="#00BFFF">- 重設</font></h5>
+        如果此功能是因錯誤或在測試期間觸發的，請按此按鈕重設。<br>
+        <br>
+        <h5><font color="#00BFFF">- 測試</font></h5>
+        模擬撥出電話以測試該號碼是否為緊急號碼。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：最高</b></font>
+        ]]>
+    </string>
+    <string name="reset">重設</string>
+    <string name="status">狀態</string>
+    <string name="inactive">停用</string>
+    <string name="confirm_reset">確認重設？</string>
+    <string name="check_stir_attestation">檢查 STIR (?)</string>
+    <string name="additional_numbers">額外號碼</string>
+    <string name="path_tags">
+        <![CDATA[
+        <font color="#00BFFF"><b>{sdcard}</b></font><br>
+        外部儲存目錄，等同於：<br>
+        <font color="#888888">/storage/emulated/0</font><br>
+        <br>
+        <font color="#00BFFF"><b>{Download}</b></font><br>
+        等同於：<br>
+        <font color="#888888">{sdcard}/Download</font><br>
+        <br>
+        <font color="#00BFFF"><b>{Documents}</b></font><br>
+        等同於：<br>
+        <font color="#888888">{sdcard}/Documents</font>
+        ]]>
+    </string>
+    <string name="call_to_number">目標號碼</string>
+    <string name="call_to">撥打給</string>
+    <string name="push_alert">推播提醒</string>
+    <string name="help_push_alert">
+        <![CDATA[
+        收到特定通知後，在設定的時間內允許所有來電。<br>
+        <br>
+        典型使用案例：<br>
+        &ensp; 當收到如下通知時：<br>
+        &emsp; 標題：<font color="#888888"><translate>訂單更新：</translate></font><br>
+        &emsp; 內容：<font color="#888888"><translate>您的訂單已由外送員 …</translate></font><br>
+        &ensp; 外送員可能會打電話給您確認詳細資訊。<br>
+        <br>
+        <b>需要權限：</b> <br>
+        1. 電池最佳化（無限制或已最佳化）<br>
+        2. 通知存取權<br>
+        <br>
+        選項：<br>
+        <br>
+        <h6><font color="#00BFFF">- 應用程式</font></h6>
+        只會檢查來自此應用程式的通知。<br>
+        <br>
+        <h6><font color="#00BFFF">- 通知內容</font></h6>
+        此正規表示式將符合<b>通知標題和內文</b>。<br>
+        上述使用案例的範例：<br>
+        &emsp; <font color="#03DAC5"><translate>訂單更新.*已由外送員.*</translate></font><br>
+        <br>
+        <h6><font color="#00BFFF">- 持續時間</font></h6>
+        在此期間將允許來電，以分鐘為單位。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：10</b></font>
+        ]]>
+    </string>
+    <string name="notification_content">通知內容</string>
+    <string name="app">應用程式</string>
+    <string name="choose">選擇</string>
+    <string name="usage_statistics">使用統計</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_18.xml
+++ b/app/src/main/res/values-zh-rTW/strings_18.xml
@@ -1,0 +1,85 @@
+<resources>
+    <string name="auto_copy">自動複製</string>
+    <string name="help_auto_copy">自動將內容複製到剪貼簿，不必在通知裡點選 [複製] 按鈕。</string>
+    <string name="calendar_event">行事曆事件</string>
+    <string name="calendar_event_is_triggered">行事曆事件 %s 已觸發。</string>
+    <string name="event_title">事件標題</string>
+    <string name="rule_updated">已將正規表示式規則 %s 修改為：%s</string>
+    <string name="rule_updated_temporarily">已暫時將正規表示式規則 %s 修改為：%s</string>
+    <string name="help_calendar_event_template">
+        <![CDATA[
+        依照行事曆事件暫時修改正規表示式規則。<br>
+        <br>
+        <b>使用情境</b>：<br>
+        &ensp; <font color="#888888">排班人員連續兩天白班，接著兩天夜班；<br>
+        &ensp; 需要依照不同工時啟用或停用部分規則。</font><br>
+        <br>
+        這會同時建立正規表示式規則與工作流程，該規則會在指定的行事曆事件期間即時啟用。<br>
+        ]]>
+    </string>
+    <string name="help_calendar_event_title">請輸入行事曆事件的名稱，需與行事曆 App 中建立的事件一致。</string>
+    <string name="help_calendar_event">
+        <![CDATA[
+        依照行事曆事件暫時調整正規表示式規則，變更只在記憶體中生效，不會改動設定檔。<br>
+        <br>
+        此工作流程會在接到來電時自動觸發。<br>
+        <br>
+        請參考工作流程預設範本了解<b>使用情境</b>與<b>常見設定</b>。<br>
+        ]]>
+    </string>
+    <string name="working">運作中</string>
+    <string name="sms_event">簡訊事件</string>
+    <string name="help_sms_event">
+        <![CDATA[
+        會在簡訊進入篩選前自動觸發。<br>
+        <br>
+        此動作必須放在工作流程的第一步。<br>
+        <br>
+        可以與 <b>[尋找規則]</b>、<b>[修改規則]</b> 等動作串聯。<br>
+        - 當簡訊號碼與內容符合條件時，工作流程會持續執行。<br>
+        - 否則工作流程會終止。<br>
+        ]]>
+    </string>
+    <string name="sms_event_triggered">簡訊事件 %s 已觸發。</string>
+    <string name="use_global_testing_instead">請改用全域測試。</string>
+    <string name="missing_permissions">下列權限先前已授予，但目前未啟用：</string>
+    <string name="grant_permissions">授予權限</string>
+    <string name="perm_call_screening">電話篩選</string>
+    <string name="perm_file_read">讀取檔案</string>
+    <string name="perm_file_write">寫入檔案</string>
+    <string name="perm_contacts">聯絡人</string>
+    <string name="perm_receive_sms">接收簡訊</string>
+    <string name="perm_receive_mms">接收 MMS</string>
+    <string name="perm_answer_calls">接聽來電</string>
+    <string name="perm_call_logs">通話紀錄</string>
+    <string name="perm_phone_state">電話狀態</string>
+    <string name="perm_read_sms">讀取簡訊</string>
+    <string name="perm_read_calendar">讀取行事曆</string>
+    <string name="perm_notification_access">通知存取權</string>
+    <string name="perm_usage_stats">使用情況統計</string>
+    <string name="perm_battery_unrestricted">電池用量不受限制</string>
+    <string name="include_sms">包含簡訊</string>
+    <string name="minimal_duration">最短持續時間</string>
+    <string name="answered_number"><short>已接來電號碼</short></string>
+    <string name="help_answered">
+        <![CDATA[
+        允許之前接聽過的來電。<br>
+        <br>
+        <h6><font color="#ffa500">警告</font></h6>
+        %s<br>
+        <br>
+        <b>選項：</b><br>
+        <br>
+        <h6><font color="#00BFFF">- [天數範圍]</font></h6>
+        會忽略 <font color="cyan">%d 天</font>之前的來電。<br>
+        <br>
+        <h6><font color="#00BFFF">- [最短通話時間]</font></h6>
+        會忽略通話時間少於 <font color="cyan">%d 秒</font>的通話。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：10</b></font>
+        ]]>
+    </string>
+    <string name="answered_warning">請勿為長者或較難辨識詐騙來電的人啟用此功能，以免讓詐騙電話重複撥入。</string>
+    <string name="acknowledged">已確認</string>
+    <string name="warning">警告</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_19.xml
+++ b/app/src/main/res/values-zh-rTW/strings_19.xml
@@ -1,0 +1,138 @@
+<resources>
+    <string name="call_event">來電事件</string>
+    <string name="call_event_is_triggered">來電事件 %s 已觸發。</string>
+    <string name="help_call_event">
+        <![CDATA[
+        在規則檢查前先預處理來電號碼，讓規則可以即時調整。<br>
+        <br>
+        此動作必須放在工作流程的第一步，該工作流程會在有來電時自動觸發。<br>
+        <br>
+        <font color="#00BFFF"><b>常見的工作流程：</b></font><br>
+        - <b>[來電事件]</b> <br>
+        - <b>[修改號碼]</b>
+        ]]>
+    </string>
+    <string name="action_modify_number">修改號碼</string>
+    <string name="modify_number_template">已將來電號碼 %s 轉換為 %s。</string>
+    <string name="help_action_modify_number">
+        <![CDATA[
+        在規則檢查前先修改來電號碼。<br>
+        <br>
+        <font color="#00BFFF"><b>使用情境</b>：</font><br>
+        &ensp; 部分電信商提供雙號服務，會在次要號碼前加上額外前置號碼。<br>
+        &ensp; 例如：3312345679 可能變成 <font color="#888888">123</font>3312345679。<br>
+        &ensp; 檢查前必須先移除前置號碼 <font color="#888888">123</font>。<br>
+        <br>
+        <font color="#00BFFF"><b>典型設定：</b></font><br>
+        - <b>[來電事件]</b> <br>
+        - <b>[取代號碼]</b> <br>
+        &emsp; from: <font color="#888888">^123</font> <br>
+        &emsp; to: <font color="#888888">保留空白</font>
+        ]]>
+    </string>
+    <string name="help_notification">
+        <![CDATA[
+        內建通知頻道：<br>
+        <br>
+        <font color="#00BFFF"><b>[無]</b></font> &ensp; <img src=\'ic_bell_mute\'/> <br>
+        &ensp; 不顯示任何通知。<br>
+        <br>
+        <font color="#00BFFF"><b>[低]</b></font> &ensp; <img src=\'ic_statusbar_shade\'/> <br>
+        &ensp; 會在狀態列與通知面板顯示。<br>
+        <br>
+        <font color="#00BFFF"><b>[中]</b></font> &ensp; <img src=\'ic_bell_ringing\'/><img src=\'ic_statusbar_shade\'/> <br>
+        &ensp; 會在狀態列與通知面板顯示，並播放音效。<br>
+        <br>
+        <font color="#00BFFF"><b>[高]</b></font> &ensp; <img src=\'ic_bell_ringing\'/><img src=\'ic_statusbar_shade\'/><img src=\'ic_heads_up\'/> <br>
+        &ensp; 會在狀態列、通知面板與浮出通知顯示，並播放音效。<br>
+        <br>
+        <font color="#00BFFF"><b>[高（靜音）]</b></font> &ensp; <img src=\'ic_statusbar_shade\'/><img src=\'ic_heads_up\'/> <br>
+        &ensp; 與 <b>高</b> 類似，但強制靜音。<br>
+        &ensp; 很適合持續進行的 <font color="#03DAC5"><b>簡訊聊天</b></font>，避免連續的音效造成干擾。<br>
+        &ensp; 系統偵測螢幕解鎖且簡訊 App 在前景時，就會視為正在進行 <font color="#03DAC5"><b>簡訊聊天</b></font>。<br>
+        ]]>
+    </string>
+    <string name="none">無</string>
+    <string name="low">低</string>
+    <string name="medium">中</string>
+    <string name="high">高</string>
+    <string name="high_muted">高（靜音）</string>
+    <string name="sms_chat">簡訊聊天</string>
+    <string name="blocked">封鎖</string>
+    <string name="allowed">允許</string>
+    <string name="call_channel">通話頻道</string>
+    <string name="sms_channel">簡訊頻道</string>
+    <string name="channel_id">頻道 ID</string>
+    <string name="help_channel_id">
+        <![CDATA[
+        此 ID 會在系統設定中顯示為通知頻道。<br>
+        <br>
+        建立後無法再修改。
+        ]]>
+    </string>
+    <string name="channel_importance">重要性</string>
+    <string name="help_channel_importance">
+        <![CDATA[
+        只能在建立新頻道時設定重要性，建立後只能到系統設定調整。<br>
+        ]]>
+    </string>
+    <string name="channel_group">頻道群組</string>
+    <string name="help_channel_group">
+        <![CDATA[
+        保留空白時，通知會自動分成三種類別：<br>
+        <br>
+        - 垃圾來電 <br>
+        - 垃圾簡訊 <br>
+        - 合法簡訊 <br>
+        <br>
+        如果指定群組，系統會依據群組分開顯示。<br>
+        ]]>
+    </string>
+    <string name="mute">靜音</string>
+    <string name="sound">音效</string>
+    <string name="help_sound">
+        <![CDATA[
+        只能在建立新頻道時指定音效，建立後只能到系統設定調整。<br>
+        <br>
+        <b>自訂音效</b><br>
+        部分手機允許透過 App 直接匯入自訂鈴聲。<br>
+        其餘裝置可先在系統設定匯入，再於 App 中選取。<br>
+        ]]>
+    </string>
+    <string name="default_">預設</string>
+    <string name="select_notification_sound">選擇通知音效</string>
+    <string name="unknown">未知</string>
+    <string name="icon_color">圖示顏色</string>
+    <string name="confirm_to_delete">確定要刪除嗎？</string>
+    <string name="help_create_notification_channel">
+        <![CDATA[
+        建立新的通知頻道。<br>
+        <br>
+        在此下拉清單長按通知頻道即可編輯。<br>
+        ]]>
+    </string>
+    <string name="warning_delete_channel">
+        <![CDATA[
+        目前下列規則正在使用此頻道。<br>
+        <br>
+        %s<br>
+        <br>
+        刪除頻道後請記得更新這些規則。<br>
+        ]]>
+    </string>
+    <string name="help_mute_channel">
+        <![CDATA[
+        會強制將此通知頻道靜音，即使設定為高重要性也會停用音效。
+        ]]>
+    </string>
+    <string name="led">LED</string>
+    <string name="led_color">LED 顏色</string>
+    <string name="help_led_color">
+        <![CDATA[
+        只能在建立新頻道時設定指示燈顏色，建立後只能到系統設定調整。<br>
+        ]]>
+    </string>
+    <string name="icon">圖示</string>
+    <string name="automatic">自動</string>
+    <string name="tap_text_to_edit_color">點選 ARGB 文字即可手動輸入顏色。</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_2.xml
+++ b/app/src/main/res/values-zh-rTW/strings_2.xml
@@ -1,0 +1,59 @@
+<resources>
+    <string name="contacts">聯絡人</string>
+    <string name="non_contacts">非聯絡人</string>
+    <string name="lenient">寬鬆</string>
+    <string name="strict">嚴格</string>
+    <string name="help_contacts">
+        <![CDATA[
+        允許聯絡人的號碼。<br>
+        <br>
+        同時適用於通話與簡訊。<br>
+        <br>
+        <b>選項：</b><br>
+        <br>
+        - <b>寬鬆</b>：<br>
+            &emsp; 聯絡人的號碼會直接放行。<br>
+            &emsp; 非聯絡人的號碼會交由其他規則檢查。<br>
+            &emsp; <font color="#ea86ff"><b>預設優先順序：10</b></font><br>
+        <br>
+        - <font color="#fa7f71"><b>嚴格</b></font>：<br>
+            &emsp; 聯絡人的號碼會直接放行。<br>
+            &emsp; 非聯絡人的號碼會被<font color="#fa7f71"><b>封鎖</b></font>。<br>
+            &emsp; <font color="#ea86ff"><b>預設優先順序：0</b></font><br>
+        ]]>
+    </string>
+    <string name="stir_attestation">STIR</string>
+    <string name="stir_include_unverified">包含未驗證</string>
+    <string name="unverified">未驗證</string>
+    <string name="valid">有效來電</string>
+    <string name="spoof">偽造來電</string>
+    <string name="help_stir">
+        <![CDATA[
+        封鎖未獲 STIR/SHAKEN 認證的來電，這類來電很可能是冒名撥號。<br>
+        <br>
+        STIR/SHAKEN 認證需要 <b>Android 11+</b> 與 <b>電信業者支援</b>。<br>
+        <br>
+        <b>選項：</b><br>
+        <br>
+        <font color="#00BFFF"><b>包含未驗證</b></font><br>
+        啟用後會封鎖未驗證的來電，代表該通話無法驗證，或是業者／裝置尚未支援 STIR 認證。<br>
+        <b>使用情境</b>：<br>
+        &ensp; 在嚴格要求 STIR 認證的地區，未驗證的來電通常是騷擾電話。<br>
+        <br>
+        <font color="#ea86ff"><b>預設優先順序：0</b></font><br>
+        自訂優先順序範例：<br>
+        <br>
+        1. 永遠允許聯絡人：<br>
+          &emsp; 聯絡人（寬鬆），優先順序 <font color="#ea86ff">12</font><br>
+        2. 即使重複來電，只要 STIR 失敗就封鎖：<br>
+          &emsp; STIR，優先順序 <font color="#ea86ff">11</font><br>
+        3. 允許重複來電：<br>
+          &emsp; 重複來電，優先順序 <font color="#ea86ff">10</font><br>
+        ]]>
+    </string>
+    <string name="failed_to_import_from_csv">
+        <![CDATA[
+        CSV 檔案缺少必要欄位 <b>pattern</b>，請檢查 [號碼規則] 的提示氣泡以取得詳細說明。
+        ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_20.xml
+++ b/app/src/main/res/values-zh-rTW/strings_20.xml
@@ -1,0 +1,102 @@
+<resources>
+    <string name="enable_call_screening_first">請先啟用電話篩選。</string>
+    <string name="enable_sms_screening_first">請先啟用簡訊篩選。</string>
+    <string name="it_is_at_top">它就在最上方。</string>
+    <string name="category_mapping">分類對應</string>
+    <string name="help_category_mapping">
+    <![CDATA[
+        部分 API 會以數字表示分類，例如 <b>1</b> 代表 <b>廣告</b>、<b>2</b> 代表 <b>詐騙</b>。
+        可將它們對應成易讀的文字。
+    ]]>
+    </string>
+    <string name="category_mapping_placeholder">
+        {\n
+        \"1\": \"廣告\",\n
+        \"2\": \"詐騙\",\n
+        …\n
+        }
+    </string>
+    <string name="call_throttling">來電節流</string>
+    <string name="call_throttling_triggered">已啟用來電節流</string>
+    <string name="help_call_throttling_template">
+    <![CDATA[
+    在封鎖來電後，於一段時間內將所有繞過規則的來電一併封鎖。<br>
+    <br>
+    <b>使用情境：</b><br>
+    <font color="#888888">&ensp; 某些騷擾電話會使用共同前置號碼，可藉由正規表示式封鎖。第一通被擋後，對方改用隨機號碼，可能繞過所有規則。</font><br>
+    <br>
+    <font color="#ffa500"><b>注意：</b></font><br>
+      可能會連帶封鎖正常來電，需要在安全性與方便性之間權衡。<br>
+    <br>
+    系統會同時建立<b>一條正規表示式規則</b>與<b>一個工作流程</b>，詳細行為請參考內部動作 <b>[來電節流]</b> 的提示說明。<br>
+    ]]>
+    </string>
+    <string name="help_call_throttling">
+    <![CDATA[
+    此功能會在一段時間內，把預設行為從<b>預設允許</b>改成<b>預設封鎖</b>，並啟用暫時性的正規表示式規則來封鎖所有來電。<br>
+    <br>
+    常見設定包含：<br>
+    &ensp; - 停用中的號碼正規表示式規則，會在需要時啟用來封鎖特定號碼或聯絡人群組。<br>
+    &ensp; - 一個 <b>[來電節流]</b> 工作流程。<br>
+    <br>
+    此組合已收錄在工作流程預設範本中。<br>
+    <br>
+    <b>選項：</b><br>
+    <br>
+    - <font color="#00BFFF"><b>[持續時間]</b></font><br>
+    在這段時間內封鎖來電（單位：秒）。<br>
+    <br>
+    - <font color="#00BFFF"><b>[包含已封鎖]</b></font><br>
+    只要任何來電被封鎖，就會啟用此功能。<br>
+    <br>
+    - <font color="#00BFFF"><b>[包含已接聽]</b></font><br>
+    - <font color="#00BFFF"><b>[最短通話時間]</b></font><br>
+    若接聽的通話時間過短，也會視為垃圾來電並啟用此功能。<br>
+    ]]>
+    </string>
+    <string name="template_generated">已建立範本。</string>
+    <string name="throttled_sms">節流簡訊</string>
+    <string name="throttled_call">節流來電</string>
+    <string name="including_blocked">包含已封鎖</string>
+    <string name="including_answered">包含已接聽</string>
+    <string name="minimal_call_duration">最短通話時間</string>
+    <string name="duration_in_seconds">持續時間（秒）</string>
+    <string name="seconds_template">%d 秒</string>
+    <string name="sms_throttling">簡訊節流</string>
+    <string name="sms_throttling_triggered">已啟用簡訊節流</string>
+    <string name="count_limit">次數上限</string>
+    <string name="target_rule_desc">目標規則描述</string>
+    <string name="help_sms_throttling_template">
+    <![CDATA[
+    在一段時間內靜音同一個號碼的連續簡訊通知。<br>
+    <br>
+    <b>使用情境：</b><br>
+    <font color="#888888">允許前 3 則通知，並在 1 分鐘內靜音其餘通知。</font><br>
+    <br>
+    系統會同時建立<b>一條正規表示式規則</b>與<b>一個工作流程</b>，詳細行為請參考內部動作 <b>[簡訊節流]</b> 的提示說明。<br>
+    ]]>
+    </string>
+    <string name="help_sms_throttling">
+    <![CDATA[
+    在一段時間內靜音同一個號碼的連續簡訊通知。<br>
+    <br>
+    常見設定包含：<br>
+    &ensp; - 停用中的號碼正規表示式規則，會在需要時啟用來封鎖所有來電。<br>
+    &ensp; - 一個 <b>[簡訊節流]</b> 工作流程。<br>
+    <br>
+    此組合已收錄在工作流程預設範本中。<br>
+    <br>
+    <b>選項：</b><br>
+    <br>
+    - <font color="#00BFFF"><b>[持續時間]</b></font><br>
+    簡訊會在這段時間內被靜音（單位：秒）。<br>
+    <br>
+    - <font color="#00BFFF"><b>[次數上限]</b></font><br>
+    允許前 N 次通知。<br>
+    <br>
+    - <font color="#00BFFF"><b>[包含已接聽]</b></font><br>
+    - <font color="#00BFFF"><b>[最短通話時間]</b></font><br>
+    若接聽的通話時間過短，也會視為垃圾來電並觸發此功能。<br>
+    ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_21.xml
+++ b/app/src/main/res/values-zh-rTW/strings_21.xml
@@ -1,0 +1,66 @@
+<resources>
+    <string name="perm_write_settings">寫入設定</string>
+    <string name="set_to">設定為</string>
+    <string name="help_set_ringtone_to">
+    <![CDATA[
+        為特定功能指定鈴聲，或將其靜音。<br>
+        <br>
+        例如要為某個正規表示式規則設定鈴聲：<br><br>
+        <font color="#888888">
+        &emsp; { \"regex\": \"rule_desc\" }
+        </font>
+        <br><br>
+        符合該規則並被允許的來電會播放指定鈴聲。<br>
+    ]]>
+    </string>
+    <string name="ringtone">鈴聲</string>
+    <string name="call_to_test_ringtone">請實際撥打一通電話測試鈴聲。</string>
+    <string name="help_ringtone">
+    <![CDATA[
+        為特定功能自訂鈴聲，被允許的來電會播放指定鈴聲。
+    ]]>
+    </string>
+    <string name="help_preset_ringtone">
+    <![CDATA[
+        為正規表示式規則自訂鈴聲，當來電被此規則允許時，將會播放指定的鈴聲。
+    ]]>
+    </string>
+    <string name="help_target_rule_desc">
+    <![CDATA[
+        此設定會套用到描述相同的正規表示式規則。<br>
+        <br>
+        例如想套用到名稱為 <b>Work</b> 的規則，請在此欄位輸入 <b>Work</b>。<br>
+    ]]>
+    </string>
+    <string name="invalid_config">設定無效</string>
+    <string name="custom">自訂</string>
+    <string name="quick_tile">快速設定磁貼</string>
+    <string name="help_quick_tile">
+    <![CDATA[
+        將工作流程綁定到快速設定磁貼。當磁貼處於啟用狀態且有來電時，就會執行該工作流程。<br>
+        <br>
+        可用於即時調整設定，變更只在記憶體中生效，不會寫入設定檔。<br>
+        <br>
+        <b>範例：</b><br>
+        使用磁貼切換某條正規表示式規則：<br>
+        - [快速設定磁貼] <br>
+        - [尋找規則] <br>
+        - [修改規則] <br>
+    ]]>
+    </string>
+    <string name="quick_tile_is_active">自訂快速設定磁貼已啟用。</string>
+    <string name="http_status_code_template">HTTP 狀態碼：%d</string>
+    <string name="remote_setup">遠端設定</string>
+    <string name="help_remote_setup">
+    <![CDATA[
+        為長輩遠端設定應用程式。<br>
+        <br>
+        <b>運作方式：</b><br>
+        此工作流程會每天自動從指定的網址下載並套用備份檔案。<br>
+        當您想遠端更新時，只需上傳新的備份檔案，它就會自動被套用。<br>
+        <br>
+        <b>提示：</b><br>
+        您可以將備份檔案託管在 GitHub 上。
+    ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_3.xml
+++ b/app/src/main/res/values-zh-rTW/strings_3.xml
@@ -1,0 +1,57 @@
+<resources>
+    <string name="help_sms_content_filter">
+        <![CDATA[
+        這些規則用於過濾簡訊內容。<br>
+        <br>
+        <font color="#00BFFF"><b> - 常見的規則範例</b></font>：<br>
+        &ensp; - 包含「驗證」：<font color="#03DAC5"><b>.*驗證.*</b></font><br>
+        &ensp; - 包含任一關鍵字：<font color="#03DAC5"><b>.*(警察|醫院|驗證).*</b></font>
+        ]]>
+    </string>
+    <string name="help_quick_copy">
+        <![CDATA[
+        快速從簡訊或電話號碼複製內容的方法，方便擷取驗證碼或來電號碼。<br>
+        <br>
+        符合規則時，通知中會出現類似 <font color="#00BFFF"><b>複製：123456</b></font> 的按鈕。<br>
+        <br>
+        擷取驗證碼的規則範例：<br>
+        &emsp; 使用擷取群組：<br>
+        &emsp;&emsp; <font color="#03DAC5"><b>驗證碼.*?(\\d+)</b></font><br>
+        &emsp; 另一種使用環顧的方法：<br>
+        &emsp;&emsp; <font color="#03DAC5"><b>(?&lt;=驗證碼.{0,3})\\d+</b></font>
+        ]]>
+    </string>
+    <string name="help_apply_to_call_sms">
+        <![CDATA[
+        為通話、簡訊或兩者啟用此規則。<br>
+        取消勾選這些核取方塊可停用規則而不需刪除。
+        ]]>
+    </string>
+    <string name="help_apply_to_number_and_message">
+        <![CDATA[
+        勾選 <font color="#00BFFF"><b>號碼</b></font> 時，此規則會從來電號碼擷取內容。
+        例如，使用 <b>(.*)</b> 來複製電話號碼。<br>
+        <br>
+        勾選 <font color="#00BFFF"><b>內容</b></font> 時，此規則會從簡訊內容擷取內容，
+        例如驗證碼。
+        ]]>
+    </string>
+    <string name="help_apply_to_passed_and_blocked">
+        <![CDATA[
+        勾選 <font color="#03DAC5"><b>放行</b></font> 時，此規則會套用於已放行的通話和簡訊。<br>
+        <br>
+        勾選 <font color="#fa7f71"><b>封鎖</b></font> 時，此規則會套用於已封鎖的通話和簡訊。
+        ]]>
+    </string>
+    <string name="title_rule_testing">規則測試</string>
+    <string name="help_test_rules">
+        <![CDATA[
+        這可以幫助檢查規則是否如預期設定。<br>
+        <br>
+        這只是模擬測試，不會真的彈出來電（或簡訊）視窗。<br>
+        <br>
+        結果會顯示在此處、歷史記錄中，並帶有通知。
+        ]]>
+    </string>
+
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_4.xml
+++ b/app/src/main/res/values-zh-rTW/strings_4.xml
@@ -1,0 +1,39 @@
+<resources>
+    <string name="help_off_time">
+        <![CDATA[
+        啟用時，在此時段內的所有通話（簡訊）都會放行。通常夜間不會有騷擾電話。<br>
+        <br>
+        如果開始時間晚於結束時間，例如 20:00 -> 07:00，表示從晚上 20:00 到隔天早上 07:00 的時段。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：10</b></font>
+        ]]>
+    </string>
+
+    <string name="help_regex_flags">
+        <![CDATA[
+            這些標記會改變正規表示式的比對行為。<br>
+            <br>
+            <font color="#00BFFF"><b>原始號碼</b></font>：<br>
+            &ensp; 啟用時，號碼不會被最佳化，<font color="#03DAC5"><b>+</b></font>
+            和<font color="#03DAC5"><b>前置零</b></font>將被保留，適合用於區分本地號碼。<br>
+            <br>
+            <font color="#00BFFF"><b>省略國碼</b></font>：<br>
+            &ensp; 啟用時，將移除國際號碼開頭的<font color="#fa7f71">+</font>和<font color="#fa7f71">國碼</font>。<br>
+            <br>
+            例如，<font color="#fa7f71">+33</font><font color="#03DAC5">12345</font> 和
+            <font color="#fa7f71">+44</font><font color="#03DAC5">12345</font> 都會變成 <font color="#03DAC5">12345</font>，
+            這讓您可以使用較簡單的正規表示式 `123.*` 而不是 `(33|44)*123.*` 來符合國際號碼。<br>
+            <br>
+            <font color="#00BFFF"><b>區分大小寫</b></font>：<br>
+            &ensp; 預設情況下，正規表示式比對不區分大小寫，<font color="#03DAC5"><b>a</b></font>
+              同時會符合 <font color="#03DAC5"><b>a</b></font> 與 <font color="#03DAC5"><b>A</b></font>。<br>
+            &ensp; 啟用此標記即可改為區分大小寫。<br>
+        ]]>
+    </string>
+    <string-array name="regex_flags_list">
+        <item>原始號碼</item>
+        <item>省略國碼</item>
+        <item>區分大小寫</item>
+    </string-array>
+    <string name="disable_number_optimization">可以透過「原始號碼」規則標記停用此最佳化，點選右側的標記圖示即可啟用。</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_5.xml
+++ b/app/src/main/res/values-zh-rTW/strings_5.xml
@@ -1,0 +1,79 @@
+<resources>
+    <string name="dialed_number"><short>已撥號碼</short></string>
+    <string name="find_apps">尋找應用程式</string>
+    <string name="confirm_delete_all_rule">確定要刪除所有規則嗎？</string>
+    <string name="notification">通知</string>
+    <string name="type">類型</string>
+    <string name="times">次數</string>
+    <plurals name="days">
+        <item quantity="other">%d 天</item>
+    </plurals>
+    <string name="min">分鐘</string>
+    <string name="within_minutes">指定分鐘內</string>
+    <string name="within_days">指定天數內</string>
+    <string name="phone_number">電話號碼</string>
+    <string name="phone_number_abbrev">號碼</string>
+    <string name="sms_content">簡訊內容</string>
+    <string name="regex_flags">正規表示式標記</string>
+    <string name="off_time"><short>休息時間</short></string>
+    <string name="schedule">排程</string>
+    <string name="workday">工作日</string>
+    <string name="weekend">週末</string>
+    <string name="entire_day">全天</string>
+    <string name="block_type">封鎖類型</string>
+    <string name="for_particular_number">指定號碼</string>
+    <string name="help_for_particular_number">啟用時，規則只在號碼和內容都符合時才會生效。</string>
+    <string name="help_block_type">
+        <![CDATA[
+        - <font color="#00BFFF"><b>拒接</b></font>：<br>
+         與按下拒接按鈕效果相同。完全靜音運作，不會開啟鎖定螢幕。<br>
+        <br>
+        - <font color="#00BFFF"><b>靜音</b></font>：<br>
+         來電會在背景中靜音響鈴，讓來電者以為您不在而錯過電話。<br>
+        <br>
+         如果您遇到重複的騷擾電話，這也可能有幫助，因為它會延長通話時間，降低騷擾電話的效率，可能會讓他們不再打給您。<br>
+        <br>
+        - <font color="#00BFFF"><b>掛斷</b></font>：<br>
+        接聽並掛斷來電，避免進入語音信箱。<br>
+        <br>
+        <font color="#FFA500">注意</font> 鎖定螢幕可能會短暫開啟，
+        您也可能會聽到通話結束音（某些手機有選項可以關閉此音效）。<br>
+        <br>
+        - <b>延遲</b>：<br>
+        &emsp; 預設會在掛斷來電前延遲 1 秒，
+        避免因快速斷線而意外進入語音信箱。<br>
+        &emsp; 如果您想錄音，請安裝通話錄音應用程式並相應增加延遲時間。
+        ]]>
+    </string>
+    <string name="help_hang_up_delay">掛斷來電前的延遲時間（秒）。</string>
+    <string name="help_dialed">
+        <![CDATA[
+        允許已撥號碼的來電。<br>
+        <br>
+        <b>選項：</b><br>
+        <br>
+        <h6><font color="#00BFFF">- 指定天數內</font></h6>
+        會忽略 <font color="cyan">%s 天</font> 之前的通話紀錄。<br>
+        <br>
+        <h6><font color="#00BFFF">- 包含簡訊</font></h6>
+        啟用後，傳送給該號碼的簡訊也會列入判斷。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：10</b></font>
+        ]]>
+    </string>
+    <string name="help_recent_apps">
+        <![CDATA[
+        如果清單中的任何應用程式最近被使用過，就會放行來電。<br>
+        <br>
+        典型的使用案例：<br>
+        &emsp; 您剛在 PizzaApp 點了披薩，不久後他們打電話通知您要退款，因為他們要打烊了。如果在此啟用了 PizzaApp，這通電話就會被放行。<br>
+        <br>
+        預設設定 <font color="03DAC5"><b>5 分鐘</b></font> 表示如果任何應用程式在 5 分鐘內被使用過，就會放行來電，
+        「使用過」指的是啟動、停用、最小化或關閉應用程式。<br>
+        <br>
+        僅適用於來電，<b>不適用</b>於簡訊。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：10</b></font>
+        ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_6.xml
+++ b/app/src/main/res/values-zh-rTW/strings_6.xml
@@ -1,0 +1,106 @@
+<resources>
+    <string name="crash_title">
+        很抱歉，應用程式發生錯誤。\n\n
+        請複製以下內容並在 GitHub 上回報此問題，
+        回報前請移除任何敏感資訊。
+    </string>
+    <string-array name="weekdays_abbrev">
+        <item>週日</item>
+        <item>週一</item>
+        <item>週二</item>
+        <item>週三</item>
+        <item>週四</item>
+        <item>週五</item>
+        <item>週六</item>
+    </string-array>
+
+    <string-array name="block_type_list">
+        <item>拒接</item>
+        <item>靜音</item>
+        <item>掛斷</item>
+    </string-array>
+
+    <string name="show_passed">顯示已放行</string>
+    <string name="show_blocked">顯示已封鎖</string>
+
+    <string name="confirm_delete_all_records">確定要刪除所有記錄嗎？</string>
+    <string name="expiry">有效期限</string>
+    <string name="days">天</string>
+    <string name="help_log_sms_content">
+        <![CDATA[
+        啟用時，簡訊內容也會記錄在資料庫中並顯示在此清單中，停用時則不會記錄在資料庫中。<br>
+        <br>
+        - 啟用時：<br>
+        &emsp; <b>點選</b>可展開/摺疊完整訊息。<br>
+        <br>
+        - 停用時：<br>
+        &emsp; <b>點選</b>可在預設應用程式中開啟對話。
+        ]]>
+    </string>
+    <string name="copy_number">複製號碼</string>
+    <string name="add_num_to_regex_rule">將號碼新增至正規表示式規則</string>
+    <string name="add_num_to_db">將號碼新增至騷擾號碼資料庫</string>
+    <string name="mark_all_as_read">全部標示為已讀</string>
+    <string name="remove_db_number">從騷擾號碼資料庫刪除號碼</string>
+
+    <string name="language">語言</string>
+    <string name="help_language">
+        <![CDATA[
+            翻譯由 Google AI 完成，如需新增語言支援請在 GitHub 上提出議題。
+        ]]>
+    </string>
+    <string name="enabled_for_call">啟用通話功能</string>
+    <string name="enabled_for_sms">啟用簡訊功能</string>
+    <string name="repeated_call">重複來電</string>
+    <string name="help_repeated_call">
+        <![CDATA[
+        如果在一段時間內重複來電，就會放行該來電，這可能是重要來電而非騷擾電話。<br>
+        <br>
+        <b>選項：</b><br>
+        <br>
+        <h6><font color="#00BFFF">- 次數</font></h6>
+        預設設定 <font color="#03DAC5"><b>1 次 / 5 分鐘</b></font> 表示在 5 分鐘內的第二通來電將被允許。<br>
+        <br>
+        <h6><font color="#00BFFF">- 包含簡訊</font></h6>
+        啟用時，該號碼傳來的簡訊也會計入。<br>
+        <br>
+        僅適用於來電，<b>不適用</b>於簡訊。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：10</b></font>
+        ]]>
+    </string>
+
+    <string name="help_globally_enabled">
+        <![CDATA[
+        全域開關，此應用程式只在開啟時運作，
+        當您在等待特定來電/簡訊時可以關閉。<br>
+        <br>
+        也可以從<font color="#6ed0ff"><b>下拉快速設定</b></font>中切換。<br>
+        <br>
+        對於簡訊，本應用程式將接管簡訊通知，請在系統設定中
+        <font color="#fa7f71"><b>關閉預設簡訊應用程式的通知權限</b></font>，
+        否則會出現重複通知。
+        本應用程式只過濾簡訊通知，垃圾簡訊仍會出現在預設簡訊應用程式中。
+        ]]>
+    </string>
+
+    <string name="about">關於</string>
+    <string name="version">版本</string>
+    <string name="source_code">原始碼</string>
+    <string name="dismiss">關閉</string>
+    <string name="warning_running_in_work_profile">
+        此應用程式在工作設定檔中可能無法正常運作，請改為安裝在主要設定檔中。
+    </string>
+    <string-array name="import_csv_type">
+        <item>將 CSV 匯入為單一規則</item>
+        <item>將 CSV 匯入為多個規則</item>
+    </string-array>
+    <string name="warning_double_sms">
+        本應用程式將接管所有簡訊通知，
+        但預設簡訊應用程式也會顯示簡訊通知。為避免重複通知，
+        請在系統設定中停用其通知權限。\n
+        \n
+        ⚠️ 不支援 RCS。
+    </string>
+    <string name="open_settings">開啟設定</string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_7.xml
+++ b/app/src/main/res/values-zh-rTW/strings_7.xml
@@ -1,0 +1,45 @@
+<resources>
+    <string name="start_time">開始時間</string>
+    <string name="end_time">結束時間</string>
+    <string name="switch_mode">切換模式</string>
+    <string name="contact_group">聯絡人群組</string>
+    <string name="help_number_mode">
+        <![CDATA[
+        <font color="#00BFFF"><b>電話號碼</b></font>：<br>
+        &ensp; 預設模式，正規表示式會符合電話號碼。<br>
+        <br>
+        <font color="#00BFFF"><b>聯絡人</b></font>：<br>
+        &ensp; 正規表示式會符合來電號碼相關聯的聯絡人名稱。<br>
+        &ensp;  - 使用案例：<br>
+        &emsp; 使用正規表示式 `.*` 在週末封鎖所有非聯絡人。<br>
+        <br>
+        <font color="#00BFFF"><b>聯絡人群組</b></font>：<br>
+        &ensp; 正規表示式會符合來電號碼相關聯的聯絡人群組名稱，
+                 影響該群組中的所有聯絡人，因此您不需要個別新增，
+                 即使人員變動也不需要更新。<br>
+        &ensp;  - 使用案例：<br>
+        &emsp; 透過封鎖「工作」聯絡人群組在週末封鎖所有同事。
+        ]]>
+    </string>
+    <string name="text_too_long">文字太長，已停用編輯功能</string>
+    <string name="follow_system"><short>跟隨系統</short></string>
+    <string name="theme">佈景主題</string>
+    <string-array name="theme_list">
+        <item>淺色</item>
+        <item>深色</item>
+    </string-array>
+    <string-array name="rule_dropdown_menu">
+        <item>搜尋規則</item>
+        <item>複製規則</item>
+        <item>刪除規則</item>
+        <item>刪除重複規則</item>
+        <item>刪除所有（%d）規則</item>
+    </string-array>
+    <string name="confirm_delete_duplicated_rule">確定要刪除 %d 條重複的規則嗎？</string>
+    <string name="duration">持續時間</string>
+    <string name="help_recent_apps_individual_duration">
+        <![CDATA[
+        每個應用程式的個別持續時間，如果留空則會使用全域持續時間。
+        ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_8.xml
+++ b/app/src/main/res/values-zh-rTW/strings_8.xml
@@ -1,0 +1,185 @@
+<resources>
+    <string name="database">資料庫</string>
+    <string name="total">總計</string>
+    <string name="replace_from">原始值</string>
+    <string name="replace_to">取代為</string>
+    <string name="regex_pattern">正規表示式</string>
+
+    <string name="help_spam_db">
+        <![CDATA[
+        此資料庫中的號碼將被封鎖。<br>
+        <br>
+        您可以整合任何公開資料庫，甚至多個資料庫，也可以從本機檔案匯入號碼。<br>
+        <br>
+        請檢視下方「自動化」段落了解如何排程自動匯入任務。<br>
+        <br>
+        適用於通話和簡訊。<br>
+        <br>
+        <font color="#ea86ff"><b>優先順序：0</b></font>
+        ]]>
+    </string>
+    <string name="help_spam_db_ttl">
+        <![CDATA[
+        資料庫中的騷擾號碼將在 N 天後過期，過期的紀錄將自動刪除。<br>
+        <br>
+        停用時，號碼永遠不會自動刪除。
+        ]]>
+    </string>
+    <string name="customize">自訂</string>
+    <string name="workflow">工作流程</string>
+    <string name="workflows">工作流程</string>
+    <string name="automation">自動化</string>
+    <string name="help_workflows">
+        <![CDATA[
+        工作流程可用於自動執行任務，可透過排程或事件觸發。<br>
+        <br>
+        有預設範本可供快速設定，您也可以從頭開始建立，或從其他使用者分享的 JSON 檔案匯入。<br>
+        <br>
+        <b>觸發器：</b><br>
+        <br>
+        <font color="#00BFFF"><b>排程</b></font><br>
+        在特定日期和時間觸發。<br>
+        <br>
+        使用案例：<br>
+        &ensp; - 每天自動備份並僅保留 7 天的備份。<br>
+        &ensp; - 每天從 FTC-DNC 拒接來電清單自動下載騷擾電話號碼。<br>
+        <br>
+        <font color="#00BFFF"><b>行事曆事件</b></font><br>
+        如果在特定行事曆事件期間接到電話，則觸發。<br>
+        <br>
+        使用案例：<br>
+        &ensp; - 在行事曆事件「工作」期間，暫時停用規則「靜音老闆」。<br>
+        <br>
+        <font color="#00BFFF"><b>來電事件</b></font><br>
+        在有來電時觸發。<br>
+        <br>
+        使用案例：<br>
+        &ensp; - 在篩選前從電話號碼中移除多餘的前導字元，
+          因為某些電信業者在單一 SIM 卡上支援雙號碼。<br>
+        <br>
+        <font color="#00BFFF"><b>簡訊事件</b></font><br>
+        在收到簡訊時觸發。<br>
+        <br>
+        使用案例：<br>
+        &ensp; - 在收到值班或非值班簡訊後切換某些規則。<br>
+        ]]>
+    </string>
+    <string name="manual">手動</string>
+    <string name="bot_preset_dnc"><no_translate>FTC - Do Not Call 🇺🇸</no_translate></string>
+    <string name="bot_preset_cleanup_spam_db">清理騷擾號碼資料庫</string>
+    <string name="bot_preset_cleanup_history">清理歷史記錄</string>
+    <string name="bot_preset_auto_backup">自動備份</string>
+    <string name="action_cleanup_history">清理歷史記錄</string>
+    <string name="action_http_request">HTTP 請求</string>
+    <string name="action_cleanup_spam_db">清理騷擾號碼資料庫</string>
+    <string name="action_backup_export">匯出備份</string>
+    <string name="action_backup_import">匯入備份</string>
+    <string name="action_read_file">讀取檔案</string>
+    <string name="action_write_file">寫入檔案</string>
+    <string name="action_parse_csv">解析 CSV</string>
+    <string name="action_parse_xml">解析 XML</string>
+    <string name="action_regex_extract">正規表示式擷取</string>
+    <string name="action_import_to_spam_db">匯入至騷擾號碼資料庫</string>
+    <string name="action_import_as_regex_rule">匯入為正規表示式規則</string>
+    <string name="action_convert_number">取代號碼</string>
+    <string name="action_find_rules">尋找規則</string>
+    <string name="action_modify_rules">修改規則</string>
+    <string name="action_modify_rules_placeholder">
+        JSON 字串，例如：\n
+        {\n
+        "flags": 0, // 停用規則\n
+        "priority": 100,\n
+        "blockType": 0\n
+        …\n
+        }\n
+    </string>
+    <string name="help_action_http_download">
+        <![CDATA[
+        透過 HTTP 下載資料為<u>內容位元組</u>
+        ]]>
+    </string>
+    <string name="help_action_cleanup_spam_db">從騷擾號碼資料庫刪除過期的號碼。</string>
+    <string name="help_action_cleanup_history">刪除過期的歷史記錄。</string>
+    <string name="help_action_backup_export">
+        <![CDATA[
+        將目前設定匯出為<u>內容位元組</u>。
+        ]]>
+    </string>
+    <string name="help_action_backup_import">
+        <![CDATA[
+        從<u>內容位元組</u>套用設定。
+        ]]>
+    </string>
+    <string name="help_action_read_file">
+        <![CDATA[
+        從檔案取得<u>內容位元組</u>。<br>
+        <br>
+        支援的 <font color="#03DAC5"><b>path</b></font> 標籤：<br>
+        <br>
+        %s<br>
+        <br>
+        支援的 <font color="#03DAC5"><b>filename</b></font> 標籤：<br>
+        <br>
+        %s
+        ]]>
+    </string>
+    <string name="help_action_write_file">
+        <![CDATA[
+        將<u>內容位元組</u>寫入檔案。<br>
+        <br>
+        支援的 <font color="#03DAC5"><b>path</b></font> 標籤：<br>
+        <br>
+        %s<br>
+        <br>
+        支援的 <font color="#03DAC5"><b>filename</b></font> 標籤：<br>
+        <br>
+        %s
+        ]]>
+    </string>
+    <string name="help_action_parse_csv">
+        <![CDATA[
+        將 CSV <u>內容位元組</u> 解析為 <u>號碼清單</u>。
+        ]]>
+    </string>
+    <string name="help_action_parse_xml">
+        <![CDATA[
+        使用 <b>xpath</b> 解析 XML <u>內容位元組</u> 並產生 <u>號碼清單</u>。
+        ]]>
+    </string>
+    <string name="help_action_regex_extract">
+        <![CDATA[
+        使用正規表示式從 <u>內容位元組</u> 擷取 <u>號碼清單</u>。
+        ]]>
+    </string>
+    <string name="help_action_import_to_spam_db">
+        <![CDATA[
+        將 <u>號碼清單</u> 新增至騷擾號碼資料庫。
+        ]]>
+    </string>
+    <string name="help_action_import_as_regex_rule">
+        <![CDATA[
+        從 <u>號碼清單</u> 產生新的正規表示式規則。
+        ]]>
+    </string>
+    <string name="help_action_convert_number">
+        <![CDATA[
+        將 <u>號碼清單</u> 轉換為本應用程式使用的格式。<br>
+        <br>
+        例如，新增兩個取代動作：<br>
+        將 `<font color="#fa7f71">+</font>12345<font color="#fa7f71">####</font>` 轉換為 `12345<font color="#03DAC5"><b>…</b></font>`：<br>
+        <br>
+        &ensp; - 將 `<font color="#fa7f71">(+)</font>` 取代為 ``<br>
+        &ensp; - 將 `<font color="#fa7f71">(#)</font>` 取代為 `<font color="#03DAC5"><b>.</b></font>`<br>
+        ]]>
+    </string>
+    <string name="help_action_find_rules">
+        <![CDATA[
+        尋找符合特定描述的 <u>規則清單</u>。
+        ]]>
+    </string>
+    <string name="help_action_modify_rules">
+        <![CDATA[
+        修改 <u>規則清單</u> 的一個或多個屬性。
+        ]]>
+    </string>
+</resources>

--- a/app/src/main/res/values-zh-rTW/strings_9.xml
+++ b/app/src/main/res/values-zh-rTW/strings_9.xml
@@ -1,0 +1,96 @@
+<resources>
+    <string name="contact_rule">聯絡人規則</string>
+    <string name="directory">目錄</string>
+    <string name="filename">檔案名稱</string>
+    <string name="url">網址</string>
+    <string name="expiry_days">過期天數</string>
+    <string name="column_mapping">欄位對應</string>
+    <string name="include_spam_db">包含騷擾號碼資料庫</string>
+    <string name="no_config_needed">不需要設定</string>
+    <string name="optional">（選用）</string>
+
+    <string name="help_action_header">
+        <![CDATA[
+        - <font color="#03DAC5"><b>測試</b></font><br>
+        這些動作會立即執行，用於檢查是否已正確設定，
+        或者您只是想手動執行此工作流程。<br>
+        <br>
+        - <font color="#00BFFF"><b>新增</b></font><br>
+            建立新動作，可以串連多個動作以完成複雜的任務。<br>
+            各動作之間的綠色或紅色圓點表示它們是否可以串連。
+        ]]>
+    </string>
+
+    <string name="help_bot_preset_dnc">
+        <![CDATA[
+            每個工作日從
+            <a href="https://www.ftc.gov/policy-notices/open-government/data-sets/do-not-call-data">
+            <no_translate>FTC - Do Not Call</no_translate></a>
+            下載騷擾電話號碼並匯入資料庫。<br>
+            <br>
+            <font color="#ffa500"><b>注意：</b></font><br>
+            <font color="#888888">&ensp; 該資料集通常在每個工作日的東部時間中午左右更新。週末的資料會包含在週一的檔案中，假日的資料則包含在下一個工作日發布的檔案中。</font><br>
+            <br>
+            這就是為什麼工作流程會排程在 18:00 執行，因為預計屆時資料集已經可用。<br>
+            如果在測試時看到 404 錯誤，請檢查上面的連結以確認今天的資料是否已在其網站上發布。
+        ]]>
+    </string>
+    <string name="help_bot_preset_cleanup_spam_db">從騷擾號碼資料庫刪除過期的記錄。</string>
+    <string name="help_bot_preset_cleanup_history">刪除過期的通話/簡訊歷史記錄。</string>
+    <string name="help_bot_preset_auto_backup">備份所有設定。</string>
+    <string name="everyday">每天</string>
+    <string name="daily">每日</string>
+    <string name="weekly">每週</string>
+    <string name="periodically">定期</string>
+    <string name="time">時間</string>
+    <string name="workdays">工作日</string>
+
+    <string name="help_backup">
+        <![CDATA[
+        備份檔案格式為 gzip 壓縮的 JSON，您可以使用任何壓縮檔管理工具開啟和編輯。<br>
+        <br>
+        - <font color="#00BFFF"><b>包含騷擾號碼資料庫</b></font><br>
+        長按按鈕以匯出/匯入騷擾號碼資料庫。<br>
+        <br>
+        <font color="#ffa500">注意：</font><br>
+        &ensp; 在備份檔中包含騷擾號碼資料庫會大幅增加檔案大小，
+        由於資料庫會定期更新，這通常是不必要的，除非您想要複製到另一臺手機。<br>
+
+        ]]>
+    </string>
+    <string name="mode">模式</string>
+    <string-array name="regex_action_add_mode">
+        <item>建立</item>
+        <item>取代</item>
+        <item>合併</item>
+    </string-array>
+    <string name="help_regex_action_add_mode">
+        <![CDATA[
+        - <font color="#00BFFF"><b>建立</b></font><br>
+        &ensp; 永遠建立新的正規表示式規則。<br>
+        <br>
+        - <font color="#00BFFF"><b>取代</b></font><br>
+        &ensp; 會嘗試尋找具有相同<b>描述</b>的現有規則。<br>
+        &ensp;&ensp; - 如果找到，將會覆寫。<br>
+        &ensp;&ensp; - 如果找不到，將建立新規則，與<b>建立</b>模式相同。<br>
+        <br>
+        - <font color="#00BFFF"><b>合併</b></font><br>
+        &ensp;- 如果存在具有相同描述的規則，新號碼將會合併到該規則中，<br>
+         重複的號碼將自動移除。<br>
+        &ensp;- 如果不存在，將建立新規則，與<b>建立</b>模式相同。<br>
+        ]]>
+    </string>
+    <string name="action_enable_workflow">啟用工作流程</string>
+    <string name="help_action_enable_workflow">
+        <![CDATA[
+        啟用或停用此工作流程。使用案例可能是讓定期工作流程變成一次性執行。
+        ]]>
+    </string>
+    <string name="action_enable_app">啟用應用程式</string>
+    <string name="help_action_enable_app">
+        <![CDATA[
+        啟用或停用應用程式。使用案例可能是暫時停用並在幾小時後自動重新啟用。
+        ]]>
+    </string>
+
+</resources>


### PR DESCRIPTION
Summary using GitHub Copilot:

> This pull request adds a comprehensive set of Traditional Chinese (Taiwan) translations for the app's user interface and documentation. The new resources cover all major features, help texts, error messages, and configuration options, significantly improving localization and usability for zh-rTW users.
> 
> **Core UI and General Functionality:**
> 
> * Added translations for core UI elements, actions, and settings in `strings_1.xml`, including app name, filter options, whitelist/blacklist, backup/import/export, and permission prompts.
> 
> **Feature Documentation and Help Texts:**
> 
> * Provided detailed help texts and usage examples for number rules, CSV import, regex optimization, and interface interactions in `strings_10.xml`.
> * Added help texts for meeting mode, HTTP header configuration, row display settings, and regex/description line limits in `strings_11.xml`.
> * Documented instant query actions, API integration, identifier regex, filtering logic, and error handling in `strings_12.xml`.
> * Explained history/database cleanup, number/sms/time tag usage, API preset configuration, and filtering/reporting actions in `strings_13.xml`.
> * Included help and configuration for reporting numbers, HTTP POST bodies, service exclusion, spam categories, SMS alerts, and regex testing in `strings_14.xml`.
> * Added support and help for Gemini AI SMS filtering, indicator icons, MMS/RCS handling, spam SMS bomb protection, and history logging in `strings_15.xml`.