### PR TITLE
fix: change regexMatches to use containsMatchIn

### DIFF
--- a/app/src/main/java/spam/blocker/util/Util.kt
+++ b/app/src/main/java/spam/blocker/util/Util.kt
@@ -134,7 +134,7 @@ fun String.regexMatchesNumber(rawNumber: String, regexFlags: Int): Boolean {
 // For matching anything other than phone number, it won't raise exception.
 fun String.regexMatches(targetStr: String, regexFlags: Int): Boolean {
     val opts = Util.flagsToRegexOptions(regexFlags)
-    return this.toRegex(opts).matches(targetStr)
+    return this.toRegex(opts).containsMatchIn(targetStr)
 }
 
 fun String.regexExtract(html: String, regexFlags: Int): String? {


### PR DESCRIPTION
This gives better performance and no longer make the regex behave as `^$` by default

However this would change the regex behaviour, from full matching to searching in the whole text.