### PR TITLE
fix: change regexMatches to use containsMatchIn

### DIFF
--- a/app/src/main/java/spam/blocker/ui/setting/regex/RegexMode.kt
+++ b/app/src/main/java/spam/blocker/ui/setting/regex/RegexMode.kt
@@ -167,6 +167,7 @@ object RegexMode {
             // Pattern field
             RegexInputBox(
                 label = { Text(Str(labelId)) },
+                isSms = labelId == R.string.sms_content_pattern,
                 regexStr = state.pattern.value,
                 regexFlags = state.patternFlags,
                 onRegexStrChange = { newVal, hasErr ->

--- a/app/src/main/java/spam/blocker/ui/widgets/InputBox.kt
+++ b/app/src/main/java/spam/blocker/ui/widgets/InputBox.kt
@@ -459,6 +459,7 @@ fun TestRegexDialog(
     trigger: MutableState<Boolean>,
     regexStr: String,
     regexFlags: Int,
+    isSms: Boolean,
 ) {
     val C = G.palette
 
@@ -477,7 +478,11 @@ fun TestRegexDialog(
                     label = Str(R.string.test),
                     color = C.teal200,
                     onClick = {
-                        result.value = regexStr.regexMatchesNumber(regexTestString.value, regexFlags)
+                        if (isSms) {
+                            result.value = regexStr.regexMatches(regexTestString.value, regexFlags)
+                        } else {
+                            result.value = regexStr.regexMatchesNumber(regexTestString.value, regexFlags)
+                        }
                     }
                 )
             }
@@ -520,6 +525,7 @@ fun RegexInputBox(
     onFlagsChange: Lambda1<Int>,
     modifier: Modifier = Modifier,
     label: @Composable (() -> Unit)? = null,
+    isSms: Boolean = False,
     placeholder: @Composable (() -> Unit)? = null,
     leadingIcon: @Composable (() -> Unit)? = null, // it can be a clickable icon
     enableNumberFlags: Boolean = false, // enable 2 more flags
@@ -722,6 +728,7 @@ fun RegexInputBox(
                             trigger = trigger,
                             regexStr = state.text,
                             regexFlags = regexFlags.intValue,
+                            isSms = isSms,
                         )
                     }
 

--- a/app/src/main/java/spam/blocker/ui/widgets/InputBox.kt
+++ b/app/src/main/java/spam/blocker/ui/widgets/InputBox.kt
@@ -57,6 +57,7 @@ import spam.blocker.util.Util
 import spam.blocker.util.Util.regexWildcardNotSupported
 import spam.blocker.util.enabledRegexFlagsStr
 import spam.blocker.util.hasFlag
+import spam.blocker.util.regexMatches
 import spam.blocker.util.regexMatchesNumber
 import spam.blocker.util.setFlag
 
@@ -525,7 +526,7 @@ fun RegexInputBox(
     onFlagsChange: Lambda1<Int>,
     modifier: Modifier = Modifier,
     label: @Composable (() -> Unit)? = null,
-    isSms: Boolean = False,
+    isSms: Boolean = false,
     placeholder: @Composable (() -> Unit)? = null,
     leadingIcon: @Composable (() -> Unit)? = null, // it can be a clickable icon
     enableNumberFlags: Boolean = false, // enable 2 more flags

--- a/app/src/main/java/spam/blocker/util/Util.kt
+++ b/app/src/main/java/spam/blocker/util/Util.kt
@@ -134,7 +134,7 @@ fun String.regexMatchesNumber(rawNumber: String, regexFlags: Int): Boolean {
 // For matching anything other than phone number, it won't raise exception.
 fun String.regexMatches(targetStr: String, regexFlags: Int): Boolean {
     val opts = Util.flagsToRegexOptions(regexFlags)
-    return this.toRegex(opts).matches(targetStr)
+    return this.toRegex(opts).containsMatchIn(targetStr)
 }
 
 fun String.regexExtract(html: String, regexFlags: Int): String? {


### PR DESCRIPTION
This gives better performance and no longer make the regex behave as `^$` by default

Also, use the proper matching method in testing dialog

closes #567 

## TODO

- [ ] Fix `TestRegexDialog` not recognizing isSms